### PR TITLE
FIX v1 prefix in updateContext action for Context Broker

### DIFF
--- a/lib/services/orionPlugin.js
+++ b/lib/services/orionPlugin.js
@@ -307,7 +307,7 @@ function isConvenienceOperation(request) {
 function extractCBAction(req, res, callback) {
     if (isConvenienceOperation(req)) {
         inspectConvenience(req, res, callback);
-    } else if (req.url.toLowerCase().indexOf('/ngsi10/updatecontext') >= 0) {
+    } else if (req.url.toLowerCase().match(/\/(ngsi10|v1)\/updatecontext/)) {
         inspectBody(req, res, callback);
     } else {
         inspectUrl(req, res, callback);

--- a/test/unit/extract_csb_actions_test.js
+++ b/test/unit/extract_csb_actions_test.js
@@ -106,9 +106,29 @@ describe('Extract Context Broker action from request', function() {
         });
     });
 
-    describe('When a create action arrives with JSON payload', function() {
+    describe('When a create action arrives with JSON payload and the "/NGSI10" prefix', function() {
         var options = {
             uri: 'http://localhost:' + config.resource.proxy.port + '/NGSI10/updateContext',
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'Fiware-Service': 'frn:contextbroker:admin_domain:::',
+                'X-Auth-Token': 'UAidNA9uQJiIVYSCg0IQ8Q'
+            },
+            json: utils.readExampleFile('./test/orionRequests/entityCreation.json')
+        };
+
+        beforeEach(function(done) {
+            serverMocks.mockPath('/NGSI10/queryContext', mockApp, done);
+        });
+
+        it('should add the action attribute with value "create" to the request', testAction('create', options));
+    });
+
+    describe('When a create action arrives with JSON payload and the "/v1" prefix', function() {
+        var options = {
+            uri: 'http://localhost:' + config.resource.proxy.port + '/v1/updateContext',
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',


### PR DESCRIPTION
For updateContext operations the alternative prefix "/v1" didn't work. Fixed it.
