### PR TITLE
Syntax error in spec file

### DIFF
--- a/rpm/SPECS/pepProxy.spec
+++ b/rpm/SPECS/pepProxy.spec
@@ -167,7 +167,6 @@ rm -rf $RPM_BUILD_ROOT
 %{_install_dir}
 
 %changelog
-=======
 * Thu May 21 2015 Daniel Moran <daniel.moranjimenez@telefonica.com> 0.7.0
 - Add capacity to start several instances of PEP Proxy using init.d script (#211)
 - Add log debug statements for role extraction


### PR DESCRIPTION
There were a syntax error in spec file that cause the error: `error: %changelog entries must start with *` during package generation.