### PR TITLE
Task/die on redirect error

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Make the PEP Proxy die when an error is received in a request resend (#225)

--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ In order to have the proxy running, there are several basic pieces of informatio
 * `config.resourceNamePrefix`: string prefix that will be used to compose the FRN that will identify the resource to be accessed. E.g.: `fiware:`.
 * `config.bypass`: used to activate the administration bypass in the proxy. Valid values are `true` or `false`.
 * `config.bypassRoleId`: ID of the role that will be considered to have administrative rights over the proxy (so being transparently proxied without validation). Valid values are Role UUIDs. E.g.: `db50362d5f264c8292bebdb5c5783741`.
+* `config.dieOnRedirectError`: this flags changes the behavior of the PEP Proxy when an error is received when redirecting a request. If the flag is true, the PEP Proxy process is shut down immediately; if it is false, the behavior is the usual: generate a 501 Code error.
 
 ### Authentication configuration
 * `config.authentication.checkHeaders`: when the proxy is working with the access control disabled (just user authentication), indicates whether the `fiware-service` and `fiware-servicepath` headers should be checked for existance and validity (checking: the headers exist, thy are not empty and the user is really part of the service and subservice mentioned in the header). This option is ignored when authorization is enabled, and considered to be `true` (as the headers constitute a mandatory part of the authorization process). Default value is `true`.

--- a/config.js
+++ b/config.js
@@ -134,6 +134,12 @@ config.middlewares = {
 };
 
 /**
+ * If this flag is activated, whenever the pepProxy is not able to redirect a request, instead of returning a 501 error
+ * (that is the default functionality) the PEP Proxy process will exit with a -2 code.
+ */
+config.dieOnRedirectError = false;
+
+/**
  * Name of the component. It will be used in the generation of the FRN.
  */
 config.componentName = 'orion';

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -146,7 +146,14 @@ function sendRequest(req, res, next) {
 
     request(options).on('error', function handleConnectionError(e) {
         logger.error('Error forwarding the request to target proxy: %s', e.message);
-        next(new errors.TargetServerError(e.message));
+
+        if (config.dieOnRedirectError) {
+            logger.fatal('Configured to die upon error in a redirection. Stopping process.', e.message);
+
+            process.exit(-1);
+        } else {
+            next(new errors.TargetServerError(e.message));
+        }
     }).pipe(res);
 }
 

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -148,7 +148,7 @@ function sendRequest(req, res, next) {
         logger.error('Error forwarding the request to target proxy: %s', e.message);
 
         if (config.dieOnRedirectError) {
-            logger.fatal('Configured to die upon error in a redirection. Stopping process.', e.message);
+            logger.fatal('Configured to die upon error in a redirection. Stopping process.');
 
             process.exit(-1);
         } else {


### PR DESCRIPTION
Add a flag to the configuration to die on redirection error instead of returning a 501 code.

Implements #223