### PR TITLE
Makes loading of xacml templates relative to source code.

### DIFF
--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -33,6 +33,7 @@ var request = require('request'),
     mustache = require('mustache'),
     sax = require('sax'),
     fs = require('fs'),
+    path = require('path'),
     requestTemplate,
     roleTemplate;
 
@@ -194,8 +195,8 @@ function loadTemplates(callback) {
     logger.debug('Loading access validation Templates');
 
     async.series([
-        async.apply(fs.readFile, './lib/templates/validationRequest.xml', 'utf8'),
-        async.apply(fs.readFile, './lib/templates/roleTemplate.xml', 'utf8')
+        async.apply(fs.readFile, path.join(__dirname, '../templates/validationRequest.xml'), 'utf8'),
+        async.apply(fs.readFile, path.join(__dirname, '../templates/roleTemplate.xml'), 'utf8')
     ], function templateLoaded(error, results) {
         if (error) {
             logger.fatal('[VALIDATION-FATAL-001] Validation Request templates not found');


### PR DESCRIPTION
The current loading is relative to the working dir of the
process. If the process is not started from the source
code dir, the templates are not loaded and the requests
to the keypass always fail. There are instalations
where the init.d script doesn't not execute the "cd"
to the source dir.

The templates are really part of the code and not a configurable
feature to the operators, so it is changed to always load
the templates relative to the sources regardless of the
working directory location.