### PR TITLE
ADD Service ID Check in cache returning

### DIFF
--- a/lib/services/keystoneAuth.js
+++ b/lib/services/keystoneAuth.js
@@ -185,10 +185,17 @@ function retrieveUser(req, callback) {
     var userToken = req.headers[constants.AUTHORIZATION_HEADER];
 
     function processValue(cachedValue, innerCb) {
-        req.serviceId = cachedValue.serviceId;
-        req.domainName = cachedValue.domainName;
-        req.userId = cachedValue.userId;
-        innerCb(null, req.userId);
+        if (cachedValue && cachedValue.userId) {
+            req.serviceId = cachedValue.serviceId;
+            req.domainName = cachedValue.domainName;
+            req.userId = cachedValue.userId;
+            innerCb(null, req.userId);
+        } else {
+            logger.error('Undefined cache value retrieving user from Keystone for service [%s] and subservice [%s]',
+                req.headers[constants.ORGANIZATION_HEADER], req.headers[constants.PATH_HEADER]);
+
+            innerCb(new errors.KeystoneAuthenticationError(503));
+        }
     }
 
     function retrieveRequest(innerCb) {
@@ -277,9 +284,16 @@ function retrieveSubserviceId(req, callback) {
         cacheKey = domainId + subserviceName;
 
     function processValue(cachedValue, innerCb) {
-        req.subserviceId = cachedValue.subserviceId;
+        if (cachedValue && cachedValue.subserviceId) {
+            req.subserviceId = cachedValue.subserviceId;
 
-        innerCb(null, req.subserviceId);
+            innerCb(null, req.subserviceId);
+        } else {
+            logger.error('Undefined cache value retrieving subserviceId for service [%s] and subservice [%s]',
+                req.headers[constants.ORGANIZATION_HEADER], req.headers[constants.PATH_HEADER]);
+
+            innerCb(new errors.KeystoneAuthenticationError(503));
+        }
     }
 
     function retrieveRequest(innerCb) {


### PR DESCRIPTION
Add checks to prevent the PEP from failing when a wrong value is returner from the cache.