### PR TITLE
ADD Node.js version 4 to the Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 node_js:
  - "0.10"
+ - "4"
 
 branches:
   only:


### PR DESCRIPTION
Update Travis CI tests to Node.js v4.