### PR TITLE
FIX Grammar and spacing typos in test describe's

### DIFF
--- a/test/unit/iotagent_plugin-test.js
+++ b/test/unit/iotagent_plugin-test.js
@@ -69,7 +69,7 @@ describe('IOT Agent Plugin tests', function() {
             json: {}
         };
 
-        describe('When  a ' + particularCase[0] + ' request arrives to the ' +
+        describe('When a ' + particularCase[0] + ' request arrives to the ' +
         particularCase[1] + ' url of the IOT Agent through the PEP Proxy', function() {
 
             beforeEach(function(done) {

--- a/test/unit/keypass_plugin_test.js
+++ b/test/unit/keypass_plugin_test.js
@@ -77,7 +77,7 @@ describe('Keypass Plugin tests', function() {
             json: {}
         };
 
-        describe('When  a ' + particularCase[0] + ' request arrives to the ' +
+        describe('When a ' + particularCase[0] + ' request arrives to the ' +
         particularCase[1] + ' url of Keypass PAP through the PEP Proxy', function() {
 
             beforeEach(function(done) {

--- a/test/unit/loglevel_api-test.js
+++ b/test/unit/loglevel_api-test.js
@@ -73,7 +73,7 @@ describe('Log Level API', function() {
         });
     });
 
-    describe('When a the current log level is requested through the API', function() {
+    describe('When the current log level is requested through the API', function() {
         var options = {
             uri: 'http://localhost:' + config.resource.proxy.adminPort + '/admin/log',
             method: 'GET',

--- a/test/unit/perseo_plugin_test.js
+++ b/test/unit/perseo_plugin_test.js
@@ -55,7 +55,7 @@ describe('Perseo Plugin tests', function() {
         ];
 
     function apiCase(particularCase) {
-        describe('When  a ' + particularCase[0] + ' request arrives to the ' +
+        describe('When a ' + particularCase[0] + ' request arrives to the ' +
             particularCase[1] + ' url of the CEP through the PEP Proxy', function() {
 
             beforeEach(function(done) {

--- a/test/unit/rest_plugin_test.js
+++ b/test/unit/rest_plugin_test.js
@@ -115,7 +115,7 @@ describe('REST Plugin tests', function() {
             json: {}
         };
 
-        describe('When  a ' + particularCase[0] + ' request arrives to the PEP Proxy', function() {
+        describe('When a ' + particularCase[0] + ' request arrives to the PEP Proxy', function() {
             it('should mark the action as "' + particularCase[1] + '"', function(done) {
                 var extractionExecuted = false;
 

--- a/test/unit/reuse_keystone_tokens_test.js
+++ b/test/unit/reuse_keystone_tokens_test.js
@@ -88,7 +88,7 @@ describe('Reuse authentication tokens', function() {
         });
     }
 
-    describe('When a the PEP Proxy has a token and it\'s still valid', function() {
+    describe('When a PEP Proxy has a token and it\'s still valid', function() {
         var options = {
                 uri: 'http://localhost:' + config.resource.proxy.port + '/NGSI10/updateContext',
                 method: 'POST',
@@ -151,7 +151,7 @@ describe('Reuse authentication tokens', function() {
         });
     });
 
-    describe('When a the PEP Proxy has a token and it has expired', function() {
+    describe('When a PEP Proxy has a token and it has expired', function() {
         var options = {
             uri: 'http://localhost:' + config.resource.proxy.port + '/NGSI10/updateContext',
             method: 'POST',
@@ -227,7 +227,7 @@ describe('Reuse authentication tokens', function() {
         });
     });
 
-    describe('When a the PEP Proxy has an expired token and another request arrives to the proxy', function() {
+    describe('When a PEP Proxy has an expired token and another request arrives to the proxy', function() {
         var options = {
             uri: 'http://localhost:' + config.resource.proxy.port + '/NGSI10/updateContext',
             method: 'POST',


### PR DESCRIPTION
I fixed a few typos / grammar nits in the describe()'s for some tests.

'When  a' -> 'When a'
'When a the' -> 'When a'