### PR TITLE
FIX Add missing devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "grunt-contrib-clean": "~0.5.0",
     "grunt-githooks": "~0.3.1",
     "should": "*",
-    "nock": "*"
+    "nock": "*",
+    "closure-linter-wrapper": "*"
   },
   "keywords": []
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "grunt-githooks": "~0.3.1",
     "should": "*",
     "nock": "*",
-    "closure-linter-wrapper": "*"
+    "closure-linter-wrapper": "0.2.0"
   },
   "keywords": []
 }


### PR DESCRIPTION
Problem:
I'm running node v.0.10.37.

When I run the following sequence of steps:
  git clone <this project>
  cd <this project>
  npm install
  npm install --only=dev
  grunt

I get
  $ grunt
  Loading "gjslint.js" tasks...ERROR

> > Error: Cannot find module 'closure-linter-wrapper'

Solution:
Add 'closure-linter-wrapper' to devDependencies.

NB I wasn't sure what version of closure-linter-wrapper to specify.
