### PR TITLE
FIX Don't call done unless the test case passes

### DIFF
--- a/test/unit/reuse_keystone_tokens_test.js
+++ b/test/unit/reuse_keystone_tokens_test.js
@@ -276,6 +276,9 @@ describe('Reuse authentication tokens', function() {
         it('both requests should finish', function(done) {
             var bus = new EventEmitter();
 
+            var nRequests = 2;
+            var nFinishedRequests = 0;
+
             mockOAuthApp.handler = function(req, res) {
                 if (req.path === currentAuthentication.authPath && req.method === 'POST') {
                     bus.once('secondArrived', function() {
@@ -300,7 +303,10 @@ describe('Reuse authentication tokens', function() {
             bus.once('firstWaiting', function() {
                 request(options, function(error, response, body) {
                     should.not.exist(error);
-                    done();
+                    nFinishedRequests++;
+                    if (nFinishedRequests === nRequests) {
+                      done();
+                    }
                 });
 
                 setTimeout(function() {
@@ -310,6 +316,10 @@ describe('Reuse authentication tokens', function() {
 
             request(options, function(error, response, body) {
                 should.not.exist(error);
+                nFinishedRequests++;
+                if (nFinishedRequests === nRequests) {
+                  done();
+                }
             });
         });
     });


### PR DESCRIPTION
Problem:
In test case:
   'Reuse authentication tokens'
     -> 'When a PEP Proxy has an expired token and another
           request arrives to the proxy'
        -> 'both requests should finish'

We call done() without being sure that both requests have finished.

Solution:
Only call done once the second request receives a response.
When the test case fails, it now does so in the test case proper
rather than in the afterEach hook.