### PR TITLE
ADD step: 1.2.0-next -> 1.3.0

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,0 @@
-- FEATURE update node version to 4.8.4
-- FEATURE access accounting in a file of each operation (including user, service/servicepath and action) [#350]
-- FIX text/plain bodies are not forwarded (impacting on "PUT /v2/entities/E/attrs/A/value" operation for CB) [#345]
-- FIX size of validation cache according with cacheTTLS.validation instead of cacheTTLS.users [#349]

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fiware-pep-steelskin",
-  "version": "1.2.0-next",
+  "version": "1.3.0",
   "dependencies": {
     "async": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fiware-pep-steelskin",
   "description": "FiWare Policy Enforcement Point",
-  "version": "1.2.0-next",
+  "version": "1.3.0",
   "homepage": "https://github.com/telefonicaid/fiware-pep-steelskin",
   "author": {
     "name": "Daniel Moran",

--- a/rpm/SPECS/pepProxy.spec
+++ b/rpm/SPECS/pepProxy.spec
@@ -168,6 +168,12 @@ rm -rf $RPM_BUILD_ROOT
 %{_install_dir}
 
 %changelog
+* Wed Oct 18 2017 Fermin Galan <fermin.galanmarquez@telefonica.com> 1.3.0
+- FEATURE update node version to 4.8.4
+- FEATURE access accounting in a file of each operation (including user, service/servicepath and action) [#350]
+- FIX text/plain bodies are not forwarded (impacting on "PUT /v2/entities/E/attrs/A/value" operation for CB) [#345]
+- FIX size of validation cache according with cacheTTLS.validation instead of cacheTTLS.users [#349]
+
 * Tue Oct 4 2016 Daniel Moran <daniel.moranjimenez@telefonica.com> 1.2.0
 - Update Context Broker plugin with v2 operations (#325).
 - Add an administrative operation to get the log level (#323).


### PR DESCRIPTION
In this case I haven't found a clear commit to "copy". However, the changes seems to be straighforward, based in the same recent PRs for IOTAs.