### PR TITLE
[WIP] evaluate all possible subservices in a multilevel subservice

### DIFF
--- a/bin/pepProxy
+++ b/bin/pepProxy
@@ -47,6 +47,7 @@ function loadConfiguration() {
         'ACCESS_PROTOCOL',
         'ACCESS_ACCOUNT',
         'ACCESS_ACCOUNTFILE',
+        'ACCESS_MULTILEVEL',
         'ADMIN_PORT',
         'AUTHENTICATION_HOST',
         'AUTHENTICATION_PORT',
@@ -95,6 +96,9 @@ function loadConfiguration() {
     }
     if (process.env.ACCESS_ACCOUNTFILE) {
         config.access.accountFile = process.env.ACCESS_ACCOUNTFILE;
+    }
+    if (process.env.ACCESS_MULTILEVEL) {
+        config.access.multiLevel = process.env.ACCESS_MULTILEVEL == 'true';
     }
     if (process.env.AUTHENTICATION_HOST) {
         config.authentication.options.host = process.env.AUTHENTICATION_HOST;

--- a/config.js
+++ b/config.js
@@ -64,7 +64,11 @@ config.access = {
     /**
      * Log Account file
      */
-    accountFile: '/tmp/pepAccount.log'
+    accountFile: '/tmp/pepAccount.log',
+    /**
+     * Enable subservice multilevel for evaluation.
+     */
+    multiLevel: false
 };
 
 // User identity configuration

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -261,9 +261,9 @@ function validationProcess(req, res, next) {
                 logger.debug('not validated');
                 req.subService = subservice;
                 next(new errors.RolesNotFound(req.subService));
-            } else {
-                logger.debug('Request access accepted out of bucle');
-                next(null, 'Permit'); // redundant
+            // } else {
+            //     logger.debug('Request access accepted out of bucle');
+            //     next(null, 'Permit'); // redundant
             }
         } else { // if (level > 1)
             logger.debug('roles not found out of bucle');

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -226,13 +226,13 @@ function validationProcess(req, res, next) {
         // Search again roles in subservice
         var subservice = req.headers['fiware-servicepath'];
         // Get new subservice from current subservice
-        var level = subservice.split('/').length;
+        var level = subservice.split('/').length - 1;
         var validated = false;
         if (level > 2) {
             var newSubservice = subservice;
             logger.debug('analizing newSubservice %s', newSubservice);
-            var i = 0;
-            while ( (i < level) && (!validated)) {
+            var i = 1;
+            while ((i < level) && (!validated)) {
                 newSubservice = newSubservice.substring(0, subservice.lastIndexOf('/'));
                 logger.debug('Trying with subservice %s', newSubservice);
                 req.subService = newSubservice;

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -177,6 +177,7 @@ function validationRequest(roles, frn, action, headers, callback) {
                 logger.debug('Trying validation with subservice %s', newSubservice);
                 // Set new subservice in frn and headers
                 var newfrn = frn.replace(subservice, newSubservice);
+                var newcacheKey = newfrn + '#' + action + '#';
                 headers['fiware-servicepath'] = newSubservice;
                 logger.debug('Trying validation with frn %s', newfrn);
                 async.waterfall([
@@ -184,13 +185,12 @@ function validationRequest(roles, frn, action, headers, callback) {
                     apply(sendAccessRequest, headers)
                 ], function(error, decision) {
                     /* jshint ignore:start */
-                    cacheUtils.get().updating.validation[cacheKey] = false;
+                    cacheUtils.get().updating.validation[newcacheKey] = false;
                     // Recover subservice
                     headers['fiware-servicepath'] = subservice;
                     if (!error) {
                         logger.debug('Decision %s', decision);
                         var finalDecision = decision || 'Invalid';
-                        var newcacheKey = newfrn + '#' + action + '#';
                         cacheUtils.get().data.validation.set(newcacheKey, finalDecision);
                         innerCallback(null, finalDecision);
                         break;

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -158,6 +158,9 @@ function sendAccessRequest(headers, accessPayload, callback) {
 
 function validationRequest(roles, frn, action, headers, callback) {
     var cacheKey = frn + '#' + action + '#' + roles.join('-');
+    if (roles && roles.length > 0) {
+        cacheKey += roles.join('-');
+    }
 
     function processValue(cachedValue, innerCallback) {
         innerCallback(null, cachedValue);

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -261,9 +261,9 @@ function validationProcess(req, res, next) {
                 logger.debug('not validated');
                 req.subService = subservice;
                 next(new errors.RolesNotFound(req.subService));
-            // } else {
-            //     logger.debug('Request access accepted out of bucle');
-            //     next(null, 'Permit'); // redundant
+            } else {
+                logger.debug('Request access accepted out of bucle');
+                // next(null, 'Permit'); // redundant
             }
         } else { // if (level > 1)
             logger.debug('roles not found out of bucle');

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -241,16 +241,19 @@ function validationProcess(req, res, next) {
                                               req.headers, function(error, value) {
                                                   if (error) {
                                                       logger.debug('error: trying next');
+                                                      /* jshint loopfunc: true */
+                                                      requestValidated = true;
                                                   } else if (value === 'Permit') {
                                                       logger.debug('Request access accepted in bucle');
                                                       /* jshint loopfunc: true */
                                                       permit = true;
+                                                      requestValidated = true;
                                                       next(null, 'Permit');
                                                   } else {
+                                                      /* jshint loopfunc: true */
+                                                      requestValidated = true;
                                                       logger.debug('Request access denied: trying next');
                                                   }
-                                                  /* jshint loopfunc: true */
-                                                  requestValidated = true;
                                               }); // validationRequest
                             function checkValidationRequest() {
                                 if (!requestValidated) {

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -230,7 +230,6 @@ function validationProcess(req, res, next) {
         var validated = false;
         if (level > 1) {
             var newSubservice = subservice;
-            logger.debug('analizing newSubservice %s', newSubservice);
             var i = 1;
             while ((i < level) && (!validated)) {
                 newSubservice = newSubservice.substring(0, subservice.lastIndexOf('/'));
@@ -247,7 +246,6 @@ function validationProcess(req, res, next) {
                         validationRequest(req.roles, req.frn, req.action,
                                           req.headers, handleBucleValidation);
                         validated = true;
-                        logger.debug('validated with  %s', newSubservice);
                     } else {
                         logger.debug('error authorization process in subservice %s',
                                      newSubservice);
@@ -255,13 +253,9 @@ function validationProcess(req, res, next) {
                 });
                 i++;
             } // while
-            logger.debug('end bucle validating  %s', newSubservice);
             if (!validated) {
                 req.subService = subservice;
                 next(new errors.RolesNotFound(req.subService));
-            // } else {
-            //     validationRequest(req.roles, req.frn, req.action,
-            //                       req.headers, handleBucleValidation);
             }
         } else {
             next(new errors.RolesNotFound(req.subService));

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -259,6 +259,8 @@ function validationProcess(req, res, next) {
             if (!validated) {
                 req.subService = subservice;
                 next(new errors.RolesNotFound(req.subService));
+            } else {
+                next(null, 'Permit');
             }
         } else {
             next(new errors.RolesNotFound(req.subService));

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -209,6 +209,24 @@ function validationProcess(req, res, next) {
         }
     }
 
+    function handleBucleValidation(error, value) {
+        if (error) {
+            logger.debug('error: trying next');
+            /* jshint loopfunc: true */
+            requestValidated = true;
+        } else if (value === 'Permit') {
+            logger.debug('Request access accepted in bucle');
+            /* jshint loopfunc: true */
+            permit = true;
+            requestValidated = true;
+            next(null, 'Permit');
+        } else {
+            /* jshint loopfunc: true */
+            requestValidated = true;
+            logger.debug('Request access denied: trying next');
+        }
+    }
+
     function checkValidationRequest() {
         if (!requestValidated) {
             logger.debug('waiting out for validationRequest');
@@ -248,23 +266,7 @@ function validationProcess(req, res, next) {
                         if (!error) {
                             // Validate it
                             validationRequest(req.roles, req.frn, req.action,
-                                              req.headers, function(error, value) {
-                                                  if (error) {
-                                                      logger.debug('error: trying next');
-                                                      /* jshint loopfunc: true */
-                                                      requestValidated = true;
-                                                  } else if (value === 'Permit') {
-                                                      logger.debug('Request access accepted in bucle');
-                                                      /* jshint loopfunc: true */
-                                                      permit = true;
-                                                      requestValidated = true;
-                                                      next(null, 'Permit');
-                                                  } else {
-                                                      /* jshint loopfunc: true */
-                                                      requestValidated = true;
-                                                      logger.debug('Request access denied: trying next');
-                                                  }
-                                              }); // validationRequest
+                                              req.headers, handleBucleValidation);
                         } else {
                             logger.debug('error authorization process in subservice %s',
                                          newSubservice);

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -172,23 +172,25 @@ function validationRequest(roles, frn, action, headers, callback) {
             for (var i = 0; i < level; i++) {
                 newSubservice = newSubservice.substring(0,subservice.lastIndexOf('/'));
                 logger.debug('Trying validation with subservice %s', newSubservice);
-                // fix FRN and headers with new subservice
+                // Set new subservice in frn and headers
                 var newfrn = frn.replace(subservice, newSubservice);
                 headers['fiware-servicepath'] = newSubservice;
                 logger.debug('Trying validation with frn %s', newfrn);
-                logger.debug('Trying validation with headers %j', headers);
                 async.waterfall([
                     apply(createAccessRequest, roles, newfrn, action),
                     apply(sendAccessRequest, headers)
                 ], function(error, decision) {
                     // TBD Cache ?
-                    // recover subservice
+                    /* jshint ignore:start */
+                    // Recover subservice
                     headers['fiware-servicepath'] = subservice;
                     if (!error) {
                         var finalDecision = decision || 'Invalid';
-                        cacheUtils.get().data.validation.set(cacheKey, finalDecision);
+                        var newcacheKey = newfrn + '#' + action + '#' + roles.join('-');
+                        cacheUtils.get().data.validation.set(newcacheKey, finalDecision);
                         innerCallback(null, finalDecision);
                     }
+                    /* jshint ignore:end */
                 });
             } // end for
         } else {

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -215,7 +215,7 @@ function validationProcess(req, res, next) {
         logger.debug('Roles not found for subservice %s', req.subService);
 
         // TODO: check configuration to know if should evaluate all possible subservices
-
+        // if ( config.access.multilevel ) {
         // Search again roles in subservice
         var subservice = req.headers['fiware-servicepath'];
         // Get new subservice from current subservice
@@ -248,22 +248,32 @@ function validationProcess(req, res, next) {
                                               } else {
                                                   logger.debug('Request access denied: trying next');
                                               }
-                                          });
+                                          }); // validationRequest
 
                     } else {
                         logger.debug('error authorization process in subservice %s',
                                      newSubservice);
                     }
-                });
+                }); // authorization.process
                 i++;
             } // while
             if (!validated) {
+                logger.debug('not validated');
                 req.subService = subservice;
                 next(new errors.RolesNotFound(req.subService));
+            } else {
+                logger.debug('Request access accepted out of bucle');
+                next(null, 'Permit'); // redundant
             }
-        } else {
+        } else { // if (level > 1)
+            logger.debug('roles not found out of bucle');
             next(new errors.RolesNotFound(req.subService));
         }
+        // }
+        // else {
+        //    next(new errors.RolesNotFound(req.subService));
+        // }
+        // // End check configuration
     } else {
         validationRequest(req.roles, req.frn, req.action, req.headers, handleValidation);
     }

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -215,7 +215,7 @@ function validationProcess(req, res, next) {
             /* jshint loopfunc: true */
             requestValidated = true;
         } else if (value === 'Permit') {
-            logger.debug('Request access accepted in bucle');
+            logger.debug('Request access accepted');
             /* jshint loopfunc: true */
             permit = true;
             requestValidated = true;
@@ -231,18 +231,18 @@ function validationProcess(req, res, next) {
         if (!requestValidated) {
             logger.debug('waiting out for validationRequest');
             setTimeout(checkValidationRequest, 100);
-            logger.debug('afeter wait out for validationRequest');
+            logger.debug('after wait out for validationRequest');
         } else {
             logger.debug('end of wait out for validationRequest');
         }
     }
-    
+
     if (req.bypass) {
         next();
     } else if (req.roles && req.roles.length === 0) {
         logger.debug('Roles not found for subservice %s', req.subService);
 
-        // TODO: check configuration to know if should evaluate all possible subservices
+        // Check if should evaluate all possible subservices
         if (config.access.multiLevel) {
             // Search again roles in subservice
             var subservice = req.headers['fiware-servicepath'];
@@ -257,6 +257,7 @@ function validationProcess(req, res, next) {
                     logger.debug('Trying with subservice %s', newSubservice);
                     req.subService = newSubservice;
                     req.frn.replace(subservice, newSubservice);
+                    logger.debug('frn: %s', req.frn);
                     req.headers['fiware-servicepath'] = newSubservice;
                     // Get new user token for that new subservice &
                     // Get new roles in that new subservice
@@ -276,7 +277,7 @@ function validationProcess(req, res, next) {
                     i++;
                     logger.debug('next loop i %j level %j', i, level);
                 } // while
-                if (!permit) {
+                if (!permit && requestValidated) {
                     logger.debug('not permit');
                     req.subService = subservice;
                     next(new errors.RolesNotFound(req.subService));
@@ -284,7 +285,7 @@ function validationProcess(req, res, next) {
                     logger.debug('permit');
                 }
             } else { // if (level > 1)
-                logger.debug('roles not found out of bucle');
+                logger.debug('roles not found');
                 next(new errors.RolesNotFound(req.subService));
             }
         } else { 

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -35,6 +35,7 @@ var request = require('request'),
     fs = require('fs'),
     path = require('path'),
     cacheUtils = require('./cacheUtils'),
+    authorization = require('./' + config.authentication.module + 'Auth'),
     requestTemplate,
     roleTemplate;
 
@@ -167,54 +168,20 @@ function validationRequest(roles, frn, action, headers, callback) {
     }
 
     function retrieveRequest(innerCallback) {
-        // Check if subservice is a hierarchy
-        var subservice = headers['fiware-servicepath'];
-        logger.debug('retrieveRequest with subservice %s', newSubservice);
-        var level = subservice.split('/').length;
-        if (level > 2) {
-            var newSubservice = subservice;
-            for (var i = 0; i < level; i++) {
-                newSubservice = newSubservice.substring(0,subservice.lastIndexOf('/'));
-                logger.debug('Trying validation with subservice %s', newSubservice);
-                // Set new subservice in frn and headers
-                var newfrn = frn.replace(subservice, newSubservice);
-                var newcacheKey = newfrn + '#' + action + '#';
-                headers['fiware-servicepath'] = newSubservice;
-                logger.debug('Trying validation with frn %s', newfrn);
-                async.waterfall([
-                    apply(createAccessRequest, roles, newfrn, action),
-                    apply(sendAccessRequest, headers)
-                ], function(error, decision) {
-                    /* jshint ignore:start */
-                    cacheUtils.get().updating.validation[newcacheKey] = false;
-                    // Recover subservice
-                    headers['fiware-servicepath'] = subservice;
-                    if (!error) {
-                        logger.debug('Decision %s', decision);
-                        var finalDecision = decision || 'Invalid';
-                        cacheUtils.get().data.validation.set(newcacheKey, finalDecision);
-                        innerCallback(null, finalDecision);
-                        break;
-                    }
-                    /* jshint ignore:end */
-                });
-            } // end for
-        } else {
-            async.waterfall([
-                apply(createAccessRequest, roles, frn, action),
-                apply(sendAccessRequest, headers)
-            ], function(error, decision) {
-                cacheUtils.get().updating.validation[cacheKey] = false;
+        async.waterfall([
+            apply(createAccessRequest, roles, frn, action),
+            apply(sendAccessRequest, headers)
+        ], function(error, decision) {
+            cacheUtils.get().updating.validation[cacheKey] = false;
 
-                if (error) {
-                    innerCallback(error);
-                } else {
-                    var finalDecision = decision || 'Invalid';
-                    cacheUtils.get().data.validation.set(cacheKey, finalDecision);
-                    innerCallback(null, finalDecision);
-                }
-            });
-        }
+            if (error) {
+                innerCallback(error);
+            } else {
+                var finalDecision = decision || 'Invalid';
+                cacheUtils.get().data.validation.set(cacheKey, finalDecision);
+                innerCallback(null, finalDecision);
+            }
+        });
     }
 
     cacheUtils.cacheAndHold('validation', cacheKey, retrieveRequest, processValue, callback);
@@ -241,12 +208,53 @@ function validationProcess(req, res, next) {
         }
     }
 
+    function handleBucleValidation(error, value) {
+        if (error) {
+            logger.debug('error: trying next');
+        } else if (value === 'Permit') {
+            logger.debug('Request access accepted');
+            next(null, 'Permit');
+        } else {
+            logger.debug('Request access denied: trying next');
+        }
+    }
+
     if (req.bypass) {
         next();
     } else if (req.roles && req.roles.length === 0) {
         logger.debug('Roles not found for subservice %s', req.subService);
-        validationRequest(req.roles, req.frn, req.action, req.headers, handleValidation);
-        //next(new errors.RolesNotFound(req.subService));
+        // Search again roles in subservice
+        var subservice = req.headers['fiware-servicepath'];
+        // Get new subservice from current subservice
+        var level = subservice.split('/').length;
+        if (level > 2) {
+            var newSubservice = subservice;
+            logger.debug('analizing newSubservice %s', newSubservice);
+            for (var i = 0; i < level; i++) {
+                newSubservice = newSubservice.substring(0, subservice.lastIndexOf('/'));
+                logger.debug('Trying with subservice %s', newSubservice);
+                req.subService = newSubservice;
+                req.frn.replace(subservice, newSubservice);
+                req.headers['fiware-servicepath'] = newSubservice;
+                // Get new user token for that new subservice &
+                // Get new roles in that new subservice
+                authorization.process(req, res, function(error, result) {
+                    if (!error) {
+                        // Validate it
+                        validationRequest(req.roles, req.frn, req.action,
+                                          req.headers, handleBucleValidation);
+                    } else {
+                        logger.debug('error authorization process in subservice %s',
+                                     newSubservice);
+                    }
+                });
+
+            } // for
+            req.subService = subservice;
+            next(new errors.RolesNotFound(req.subService));
+        } else {
+            next(new errors.RolesNotFound(req.subService));
+        }
     } else {
         validationRequest(req.roles, req.frn, req.action, req.headers, handleValidation);
     }

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -244,8 +244,19 @@ function validationProcess(req, res, next) {
                     if (!error) {
                         // Validate it
                         validationRequest(req.roles, req.frn, req.action,
-                                          req.headers, handleBucleValidation);
-                        validated = true;
+                                          req.headers, function(error, value) {
+                                              if (error) {
+                                                  logger.debug('error: trying next');
+                                              } else if (value === 'Permit') {
+                                                  logger.debug('Request access accepted in bucle');
+                                                  /* jshint loopfunc: true */
+                                                  validated = true;
+                                                  next(null, 'Permit');
+                                              } else {
+                                                  logger.debug('Request access denied: trying next');
+                                              }
+                                          });
+
                     } else {
                         logger.debug('error authorization process in subservice %s',
                                      newSubservice);

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -260,7 +260,8 @@ function validationProcess(req, res, next) {
                 req.subService = subservice;
                 next(new errors.RolesNotFound(req.subService));
             } else {
-                next(null, 'Permit');
+                validationRequest(req.roles, req.frn, req.action,
+                                  req.headers, handleBucleValidation);
             }
         } else {
             next(new errors.RolesNotFound(req.subService));

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -279,6 +279,7 @@ function validationProcess(req, res, next) {
                     }
                     checkValidationRequest();
                     i++;
+                    logger.debug('next loop i %j level %j', i, level);
                 } // while
                 if (!permit) {
                     logger.debug('not permit');

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -208,21 +208,13 @@ function validationProcess(req, res, next) {
         }
     }
 
-    function handleBucleValidation(error, value) {
-        if (error) {
-            logger.debug('error: trying next');
-        } else if (value === 'Permit') {
-            logger.debug('Request access accepted in bucle');
-            next(null, 'Permit');
-        } else {
-            logger.debug('Request access denied: trying next');
-        }
-    }
-
     if (req.bypass) {
         next();
     } else if (req.roles && req.roles.length === 0) {
         logger.debug('Roles not found for subservice %s', req.subService);
+
+        // TODO: check configuration to know if should evaluate all possible subservices
+
         // Search again roles in subservice
         var subservice = req.headers['fiware-servicepath'];
         // Get new subservice from current subservice
@@ -232,7 +224,7 @@ function validationProcess(req, res, next) {
             var newSubservice = subservice;
             var i = 1;
             while ((i < level) && (!validated)) {
-                newSubservice = newSubservice.substring(0, subservice.lastIndexOf('/'));
+                newSubservice = newSubservice.substring(0, newSubservice.lastIndexOf('/'));
                 logger.debug('Trying with subservice %s', newSubservice);
                 req.subService = newSubservice;
                 req.frn.replace(subservice, newSubservice);

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -228,7 +228,7 @@ function validationProcess(req, res, next) {
         // Get new subservice from current subservice
         var level = subservice.split('/').length - 1;
         var validated = false;
-        if (level > 2) {
+        if (level > 1) {
             var newSubservice = subservice;
             logger.debug('analizing newSubservice %s', newSubservice);
             var i = 1;

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -215,7 +215,7 @@ function validationProcess(req, res, next) {
         logger.debug('Roles not found for subservice %s', req.subService);
 
         // TODO: check configuration to know if should evaluate all possible subservices
-        if (config.access.subServiceMultiLevel) {
+        if (config.access.multiLevel) {
             // Search again roles in subservice
             var subservice = req.headers['fiware-servicepath'];
             // Get new subservice from current subservice
@@ -282,6 +282,8 @@ function validationProcess(req, res, next) {
                 logger.debug('roles not found out of bucle');
                 next(new errors.RolesNotFound(req.subService));
             }
+        } else { 
+            next(new errors.RolesNotFound(req.subService));
         } // End check configuration
     } else {
         validationRequest(req.roles, req.frn, req.action, req.headers, handleValidation);

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -262,7 +262,7 @@ function validationProcess(req, res, next) {
                 req.subService = subservice;
                 next(new errors.RolesNotFound(req.subService));
             } else {
-                logger.debug('Request access accepted out of bucle');
+                logger.debug('validated');
                 // next(null, 'Permit'); // redundant
             }
         } else { // if (level > 1)

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -157,7 +157,7 @@ function sendAccessRequest(headers, accessPayload, callback) {
 }
 
 function validationRequest(roles, frn, action, headers, callback) {
-    var cacheKey = frn + '#' + action + '#' + roles.join('-');
+    var cacheKey = frn + '#' + action + '#';
     if (roles && roles.length > 0) {
         cacheKey += roles.join('-');
     }
@@ -169,6 +169,7 @@ function validationRequest(roles, frn, action, headers, callback) {
     function retrieveRequest(innerCallback) {
         // Check if subservice is a hierarchy
         var subservice = headers['fiware-servicepath'];
+        logger.debug('retrieveRequest with subservice %s', newSubservice);
         var level = subservice.split('/').length;
         if (level > 2) {
             var newSubservice = subservice;

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -273,6 +273,7 @@ function validationProcess(req, res, next) {
                         if (!requestValidated) {
                             logger.debug('waiting out for validationRequest');
                             setTimeout(checkValidationRequest, 100);
+                            logger.debug('afeter wait out for validationRequest');
                         } else {
                             logger.debug('end of wait out for validationRequest');
                         }

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -227,6 +227,7 @@ function validationProcess(req, res, next) {
         var subservice = req.headers['fiware-servicepath'];
         // Get new subservice from current subservice
         var level = subservice.split('/').length;
+        var validated = false;
         if (level > 2) {
             var newSubservice = subservice;
             logger.debug('analizing newSubservice %s', newSubservice);
@@ -244,6 +245,8 @@ function validationProcess(req, res, next) {
                         // Validate it
                         validationRequest(req.roles, req.frn, req.action,
                                           req.headers, handleBucleValidation);
+                        validated = true;
+                        break;
                         logger.debug('validated with  %s', newSubservice);
                     } else {
                         logger.debug('error authorization process in subservice %s',
@@ -253,8 +256,10 @@ function validationProcess(req, res, next) {
 
             } // for
             logger.debug('end bucle validating  %s', newSubservice);
-            req.subService = subservice;
-            next(new errors.RolesNotFound(req.subService));
+            if (!validated) {
+                req.subService = subservice;
+                next(new errors.RolesNotFound(req.subService));
+            }
         } else {
             next(new errors.RolesNotFound(req.subService));
         }

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -188,10 +188,12 @@ function validationRequest(roles, frn, action, headers, callback) {
                     // Recover subservice
                     headers['fiware-servicepath'] = subservice;
                     if (!error) {
+                        logger.debug('Decision %s', decision);
                         var finalDecision = decision || 'Invalid';
                         var newcacheKey = newfrn + '#' + action + '#';
                         cacheUtils.get().data.validation.set(newcacheKey, finalDecision);
                         innerCallback(null, finalDecision);
+                        break;
                     }
                     /* jshint ignore:end */
                 });

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -246,8 +246,8 @@ function validationProcess(req, res, next) {
                         validationRequest(req.roles, req.frn, req.action,
                                           req.headers, handleBucleValidation);
                         validated = true;
-                        break;
                         logger.debug('validated with  %s', newSubservice);
+                        break;                        
                     } else {
                         logger.debug('error authorization process in subservice %s',
                                      newSubservice);

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -259,9 +259,9 @@ function validationProcess(req, res, next) {
             if (!validated) {
                 req.subService = subservice;
                 next(new errors.RolesNotFound(req.subService));
-            } else {
-                validationRequest(req.roles, req.frn, req.action,
-                                  req.headers, handleBucleValidation);
+            // } else {
+            //     validationRequest(req.roles, req.frn, req.action,
+            //                       req.headers, handleBucleValidation);
             }
         } else {
             next(new errors.RolesNotFound(req.subService));

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -244,12 +244,6 @@ function validationProcess(req, res, next) {
                                                   logger.debug('Request access accepted in bucle');
                                                   /* jshint loopfunc: true */
                                                   validated = true;
-                                                  // Notify cache
-                                                  var cacheKey = req.frn + '#' + req.action + '#';
-                                                  if (req.roles && req.roles.length > 0) {
-                                                      cacheKey += req.roles.join('-');
-                                                  }
-                                                  cacheUtils.get().data.validation.set(cacheKey, 'Permit');
                                                   next(null, 'Permit');
                                               } else {
                                                   logger.debug('Request access denied: trying next');

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -221,7 +221,6 @@ function validationProcess(req, res, next) {
             // Get new subservice from current subservice
             var level = subservice.split('/').length - 1;
             var permit = false;
-            var requestValidated = false;
             if (level > 1) {
                 var newSubservice = subservice;
                 var i = 1;
@@ -234,6 +233,7 @@ function validationProcess(req, res, next) {
                     // Get new user token for that new subservice &
                     // Get new roles in that new subservice
                     /* jshint loopfunc: true */
+                    var requestValidated = false;
                     authorization.process(req, res, function(error, result) {
                         if (!error) {
                             // Validate it
@@ -255,20 +255,29 @@ function validationProcess(req, res, next) {
                                                       logger.debug('Request access denied: trying next');
                                                   }
                                               }); // validationRequest
-                            function checkValidationRequest() {
-                                if (!requestValidated) {
-                                    logger.debug('waiting for validationRequest');
-                                    setTimeout(checkValidationRequest, 100);
-                                } else {
-                                    logger.debug('end of wait for validationRequest');
-                                }
-                            }
-                            checkValidationRequest();
+                            // function checkValidationRequest() {
+                            //     if (!requestValidated) {
+                            //         logger.debug('waiting for validationRequest');
+                            //         setTimeout(checkValidationRequest, 100);
+                            //     } else {
+                            //         logger.debug('end of wait for validationRequest');
+                            //     }
+                            // }
+                            // checkValidationRequest();
                         } else {
                             logger.debug('error authorization process in subservice %s',
                                          newSubservice);
                         }
                     }); // authorization.process
+                    function checkValidationRequest() {
+                        if (!requestValidated) {
+                            logger.debug('waiting out for validationRequest');
+                            setTimeout(checkValidationRequest, 100);
+                        } else {
+                            logger.debug('end of wait out for validationRequest');
+                        }
+                    }
+                    checkValidationRequest();
                     i++;
                 } // while
                 if (!permit) {

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -164,20 +164,44 @@ function validationRequest(roles, frn, action, headers, callback) {
     }
 
     function retrieveRequest(innerCallback) {
-        async.waterfall([
-            apply(createAccessRequest, roles, frn, action),
-            apply(sendAccessRequest, headers)
-        ], function(error, decision) {
-            cacheUtils.get().updating.validation[cacheKey] = false;
+        // Check if subservice is a hierarchy
+        var subservice = headers['fiware-servicepath'];
+        var level = subservice.split('/').length;
+        if (level > 2) {
+            var newsubservice = subservice;
+            for (var i = 0; i < level; i++) {
+                newsubservice = newsubservice.substring(0,subservice.lastIndexOf('/'));
+                // fix FRN and headers with new subservice
+                var newfrn = frn.replace(subservice, newsubservice);
+                headers['fiware-servicepath'] = newsubservice;
+                async.waterfall([
+                    apply(createAccessRequest, roles, newfrn, action),
+                    apply(sendAccessRequest, headers)
+                ], function(error, decision) {
+                    // TBD Cache ?
+                    if (!error) {
+                        var finalDecision = decision || 'Invalid';
+                        cacheUtils.get().data.validation.set(cacheKey, finalDecision);
+                        innerCallback(null, finalDecision);
+                    }
+                });
+            } // end for
+        } else {
+            async.waterfall([
+                apply(createAccessRequest, roles, frn, action),
+                apply(sendAccessRequest, headers)
+            ], function(error, decision) {
+                cacheUtils.get().updating.validation[cacheKey] = false;
 
-            if (error) {
-                innerCallback(error);
-            } else {
-                var finalDecision = decision || 'Invalid';
-                cacheUtils.get().data.validation.set(cacheKey, finalDecision);
-                innerCallback(null, finalDecision);
-            }
-        });
+                if (error) {
+                    innerCallback(error);
+                } else {
+                    var finalDecision = decision || 'Invalid';
+                    cacheUtils.get().data.validation.set(cacheKey, finalDecision);
+                    innerCallback(null, finalDecision);
+                }
+            });
+        }
     }
 
     cacheUtils.cacheAndHold('validation', cacheKey, retrieveRequest, processValue, callback);

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -239,7 +239,8 @@ function validationProcess(req, res, next) {
         next();
     } else if (req.roles && req.roles.length === 0) {
         logger.debug('Roles not found for subservice %s', req.subService);
-        next(new errors.RolesNotFound(req.subService));
+        validationRequest(req.roles, req.frn, req.action, req.headers, handleValidation);
+        //next(new errors.RolesNotFound(req.subService));
     } else {
         validationRequest(req.roles, req.frn, req.action, req.headers, handleValidation);
     }

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -197,6 +197,8 @@ function validationRequest(roles, frn, action, headers, callback) {
  * @param {Function} next        Call to the next middleware in the chain.
  */
 function validationProcess(req, res, next) {
+    var originalSubservice = req.headers['fiware-servicepath'];
+
     function handleValidation(error, value) {
         if (error) {
             next(error);
@@ -219,6 +221,9 @@ function validationProcess(req, res, next) {
             /* jshint loopfunc: true */
             permit = true;
             requestValidated = true;
+            // Restore original servicepath
+            req.headers['fiware-servicepath'] = originalSubservice;
+            req.subService = originalSubservice;
             next(null, 'Permit');
         } else {
             /* jshint loopfunc: true */
@@ -256,8 +261,9 @@ function validationProcess(req, res, next) {
                     newSubservice = newSubservice.substring(0, newSubservice.lastIndexOf('/'));
                     logger.debug('Trying with subservice %s', newSubservice);
                     req.subService = newSubservice;
-                    req.frn.replace(subservice, newSubservice);
-                    logger.debug('frn: %s', req.frn);
+                    logger.debug('frn after: %s', req.frn);
+                    req.frn = req.frn.replace(subservice, newSubservice);
+                    logger.debug('frn before: %s', req.frn);
                     req.headers['fiware-servicepath'] = newSubservice;
                     // Get new user token for that new subservice &
                     // Get new roles in that new subservice
@@ -280,6 +286,8 @@ function validationProcess(req, res, next) {
                 if (!permit && requestValidated) {
                     logger.debug('not permit');
                     req.subService = subservice;
+                    // Restore original servicepath
+                    req.headers['fiware-servicepath'] = subservice;
                     next(new errors.RolesNotFound(req.subService));
                 } else {
                     logger.debug('permit');

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -238,6 +238,7 @@ function validationProcess(req, res, next) {
                 req.headers['fiware-servicepath'] = newSubservice;
                 // Get new user token for that new subservice &
                 // Get new roles in that new subservice
+                /* jshint loopfunc: true */
                 authorization.process(req, res, function(error, result) {
                     if (!error) {
                         // Validate it

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -168,17 +168,22 @@ function validationRequest(roles, frn, action, headers, callback) {
         var subservice = headers['fiware-servicepath'];
         var level = subservice.split('/').length;
         if (level > 2) {
-            var newsubservice = subservice;
+            var newSubservice = subservice;
             for (var i = 0; i < level; i++) {
-                newsubservice = newsubservice.substring(0,subservice.lastIndexOf('/'));
+                newSubservice = newSubservice.substring(0,subservice.lastIndexOf('/'));
+                logger.debug('Trying validation with subservice %s', newSubservice);
                 // fix FRN and headers with new subservice
-                var newfrn = frn.replace(subservice, newsubservice);
-                headers['fiware-servicepath'] = newsubservice;
+                var newfrn = frn.replace(subservice, newSubservice);
+                headers['fiware-servicepath'] = newSubservice;
+                logger.debug('Trying validation with frn %s', newfrn);
+                logger.debug('Trying validation with headers %j', headers);
                 async.waterfall([
                     apply(createAccessRequest, roles, newfrn, action),
                     apply(sendAccessRequest, headers)
                 ], function(error, decision) {
                     // TBD Cache ?
+                    // recover subservice
+                    headers['fiware-servicepath'] = subservice;
                     if (!error) {
                         var finalDecision = decision || 'Invalid';
                         cacheUtils.get().data.validation.set(cacheKey, finalDecision);

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -215,69 +215,68 @@ function validationProcess(req, res, next) {
         logger.debug('Roles not found for subservice %s', req.subService);
 
         // TODO: check configuration to know if should evaluate all possible subservices
-        // if ( config.access.multilevel ) {
-        // Search again roles in subservice
-        var subservice = req.headers['fiware-servicepath'];
-        // Get new subservice from current subservice
-        var level = subservice.split('/').length - 1;
-        var permit = false;
-        var requestValidated = false;
-        if (level > 1) {
-            var newSubservice = subservice;
-            var i = 1;
-            while ((i < level) && (!permit)) {
-                newSubservice = newSubservice.substring(0, newSubservice.lastIndexOf('/'));
-                logger.debug('Trying with subservice %s', newSubservice);
-                req.subService = newSubservice;
-                req.frn.replace(subservice, newSubservice);
-                req.headers['fiware-servicepath'] = newSubservice;
-                // Get new user token for that new subservice &
-                // Get new roles in that new subservice
-                /* jshint loopfunc: true */
-                authorization.process(req, res, function(error, result) {
-                    if (!error) {
-                        // Validate it
-                        validationRequest(req.roles, req.frn, req.action,
-                                          req.headers, function(error, value) {
-                                              if (error) {
-                                                  logger.debug('error: trying next');
-                                              } else if (value === 'Permit') {
-                                                  logger.debug('Request access accepted in bucle');
+        if (config.access.subServiceMultiLevel) {
+            // Search again roles in subservice
+            var subservice = req.headers['fiware-servicepath'];
+            // Get new subservice from current subservice
+            var level = subservice.split('/').length - 1;
+            var permit = false;
+            var requestValidated = false;
+            if (level > 1) {
+                var newSubservice = subservice;
+                var i = 1;
+                while ((i < level) && (!permit)) {
+                    newSubservice = newSubservice.substring(0, newSubservice.lastIndexOf('/'));
+                    logger.debug('Trying with subservice %s', newSubservice);
+                    req.subService = newSubservice;
+                    req.frn.replace(subservice, newSubservice);
+                    req.headers['fiware-servicepath'] = newSubservice;
+                    // Get new user token for that new subservice &
+                    // Get new roles in that new subservice
+                    /* jshint loopfunc: true */
+                    authorization.process(req, res, function(error, result) {
+                        if (!error) {
+                            // Validate it
+                            validationRequest(req.roles, req.frn, req.action,
+                                              req.headers, function(error, value) {
+                                                  if (error) {
+                                                      logger.debug('error: trying next');
+                                                  } else if (value === 'Permit') {
+                                                      logger.debug('Request access accepted in bucle');
+                                                      /* jshint loopfunc: true */
+                                                      permit = true;
+                                                      next(null, 'Permit');
+                                                  } else {
+                                                      logger.debug('Request access denied: trying next');
+                                                  }
                                                   /* jshint loopfunc: true */
-                                                  permit = true;
-                                                  next(null, 'Permit');
-                                              } else {
-
-                                                  logger.debug('Request access denied: trying next');
-                                              }
-                                              /* jshint loopfunc: true */
-                                              requestValidated = true;
-                                          }); // validationRequest
-                        function checkValidationRequest() {
-                            if (!requestValidated) {
-                                window.setTimeout(checkValidationRequest, 100);
+                                                  requestValidated = true;
+                                              }); // validationRequest
+                            function checkValidationRequest() {
+                                if (!requestValidated) {
+                                    window.setTimeout(checkValidationRequest, 100);
+                                }
                             }
+                            checkValidationRequest();
+                        } else {
+                            logger.debug('error authorization process in subservice %s',
+                                         newSubservice);
                         }
-                        checkValidationRequest();
-                    } else {
-                        logger.debug('error authorization process in subservice %s',
-                                     newSubservice);
-                    }
-                }); // authorization.process
-                i++;
-            } // while
-            if (!permit) {
-                logger.debug('not permit');
-                req.subService = subservice;
+                    }); // authorization.process
+                    i++;
+                } // while
+                if (!permit) {
+                    logger.debug('not permit');
+                    req.subService = subservice;
+                    next(new errors.RolesNotFound(req.subService));
+                } else {
+                    logger.debug('permit');
+                }
+            } else { // if (level > 1)
+                logger.debug('roles not found out of bucle');
                 next(new errors.RolesNotFound(req.subService));
-            } else {
-                logger.debug('permit');
             }
-        } else { // if (level > 1)
-            logger.debug('roles not found out of bucle');
-            next(new errors.RolesNotFound(req.subService));
-        }
-        // // End check configuration
+        } // End check configuration
     } else {
         validationRequest(req.roles, req.frn, req.action, req.headers, handleValidation);
     }

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -183,13 +183,13 @@ function validationRequest(roles, frn, action, headers, callback) {
                     apply(createAccessRequest, roles, newfrn, action),
                     apply(sendAccessRequest, headers)
                 ], function(error, decision) {
-                    // TBD Cache ?
                     /* jshint ignore:start */
+                    cacheUtils.get().updating.validation[cacheKey] = false;
                     // Recover subservice
                     headers['fiware-servicepath'] = subservice;
                     if (!error) {
                         var finalDecision = decision || 'Invalid';
-                        var newcacheKey = newfrn + '#' + action + '#' + roles.join('-');
+                        var newcacheKey = newfrn + '#' + action + '#';
                         cacheUtils.get().data.validation.set(newcacheKey, finalDecision);
                         innerCallback(null, finalDecision);
                     }

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -209,6 +209,16 @@ function validationProcess(req, res, next) {
         }
     }
 
+    function checkValidationRequest() {
+        if (!requestValidated) {
+            logger.debug('waiting out for validationRequest');
+            setTimeout(checkValidationRequest, 100);
+            logger.debug('afeter wait out for validationRequest');
+        } else {
+            logger.debug('end of wait out for validationRequest');
+        }
+    }
+    
     if (req.bypass) {
         next();
     } else if (req.roles && req.roles.length === 0) {
@@ -255,29 +265,11 @@ function validationProcess(req, res, next) {
                                                       logger.debug('Request access denied: trying next');
                                                   }
                                               }); // validationRequest
-                            // function checkValidationRequest() {
-                            //     if (!requestValidated) {
-                            //         logger.debug('waiting for validationRequest');
-                            //         setTimeout(checkValidationRequest, 100);
-                            //     } else {
-                            //         logger.debug('end of wait for validationRequest');
-                            //     }
-                            // }
-                            // checkValidationRequest();
                         } else {
                             logger.debug('error authorization process in subservice %s',
                                          newSubservice);
                         }
                     }); // authorization.process
-                    function checkValidationRequest() {
-                        if (!requestValidated) {
-                            logger.debug('waiting out for validationRequest');
-                            setTimeout(checkValidationRequest, 100);
-                            logger.debug('afeter wait out for validationRequest');
-                        } else {
-                            logger.debug('end of wait out for validationRequest');
-                        }
-                    }
                     checkValidationRequest();
                     i++;
                     logger.debug('next loop i %j level %j', i, level);

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -258,7 +258,7 @@ function validationProcess(req, res, next) {
                             function checkValidationRequest() {
                                 if (!requestValidated) {
                                     logger.debug('waiting for validationRequest');
-                                    window.setTimeout(checkValidationRequest, 100);
+                                    setTimeout(checkValidationRequest, 100);
                                 } else {
                                     logger.debug('end of wait for validationRequest');
                                 }

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -220,11 +220,12 @@ function validationProcess(req, res, next) {
         var subservice = req.headers['fiware-servicepath'];
         // Get new subservice from current subservice
         var level = subservice.split('/').length - 1;
-        var validated = false;
+        var permit = false;
+        var requestValidated = false;
         if (level > 1) {
             var newSubservice = subservice;
             var i = 1;
-            while ((i < level) && (!validated)) {
+            while ((i < level) && (!permit)) {
                 newSubservice = newSubservice.substring(0, newSubservice.lastIndexOf('/'));
                 logger.debug('Trying with subservice %s', newSubservice);
                 req.subService = newSubservice;
@@ -243,13 +244,21 @@ function validationProcess(req, res, next) {
                                               } else if (value === 'Permit') {
                                                   logger.debug('Request access accepted in bucle');
                                                   /* jshint loopfunc: true */
-                                                  validated = true;
+                                                  permit = true;
                                                   next(null, 'Permit');
                                               } else {
+
                                                   logger.debug('Request access denied: trying next');
                                               }
+                                              /* jshint loopfunc: true */
+                                              requestValidated = true;
                                           }); // validationRequest
-
+                        function checkValidationRequest() {
+                            if (!requestValidated) {
+                                window.setTimeout(checkValidationRequest, 100);
+                            }
+                        }
+                        checkValidationRequest();
                     } else {
                         logger.debug('error authorization process in subservice %s',
                                      newSubservice);
@@ -257,22 +266,17 @@ function validationProcess(req, res, next) {
                 }); // authorization.process
                 i++;
             } // while
-            if (!validated) {
-                logger.debug('not validated');
+            if (!permit) {
+                logger.debug('not permit');
                 req.subService = subservice;
                 next(new errors.RolesNotFound(req.subService));
             } else {
-                logger.debug('validated');
-                // next(null, 'Permit'); // redundant
+                logger.debug('permit');
             }
         } else { // if (level > 1)
             logger.debug('roles not found out of bucle');
             next(new errors.RolesNotFound(req.subService));
         }
-        // }
-        // else {
-        //    next(new errors.RolesNotFound(req.subService));
-        // }
         // // End check configuration
     } else {
         validationRequest(req.roles, req.frn, req.action, req.headers, handleValidation);

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -231,7 +231,8 @@ function validationProcess(req, res, next) {
         if (level > 2) {
             var newSubservice = subservice;
             logger.debug('analizing newSubservice %s', newSubservice);
-            for (var i = 0; i < level; i++) {
+            var i = 0;
+            while ( (i < level) && (!validated)) {
                 newSubservice = newSubservice.substring(0, subservice.lastIndexOf('/'));
                 logger.debug('Trying with subservice %s', newSubservice);
                 req.subService = newSubservice;
@@ -247,14 +248,13 @@ function validationProcess(req, res, next) {
                                           req.headers, handleBucleValidation);
                         validated = true;
                         logger.debug('validated with  %s', newSubservice);
-                        break;                        
                     } else {
                         logger.debug('error authorization process in subservice %s',
                                      newSubservice);
                     }
                 });
-
-            } // for
+                i++;
+            } // while
             logger.debug('end bucle validating  %s', newSubservice);
             if (!validated) {
                 req.subService = subservice;

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -178,6 +178,7 @@ function validationRequest(roles, frn, action, headers, callback) {
                 innerCallback(error);
             } else {
                 var finalDecision = decision || 'Invalid';
+                logger.debug('cache %s set to %s', cacheKey, finalDecision);
                 cacheUtils.get().data.validation.set(cacheKey, finalDecision);
                 innerCallback(null, finalDecision);
             }
@@ -243,6 +244,12 @@ function validationProcess(req, res, next) {
                                                   logger.debug('Request access accepted in bucle');
                                                   /* jshint loopfunc: true */
                                                   validated = true;
+                                                  // Notify cache
+                                                  var cacheKey = req.frn + '#' + req.action + '#';
+                                                  if (req.roles && req.roles.length > 0) {
+                                                      cacheKey += req.roles.join('-');
+                                                  }
+                                                  cacheUtils.get().data.validation.set(cacheKey, 'Permit');
                                                   next(null, 'Permit');
                                               } else {
                                                   logger.debug('Request access denied: trying next');

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -257,7 +257,10 @@ function validationProcess(req, res, next) {
                                               }); // validationRequest
                             function checkValidationRequest() {
                                 if (!requestValidated) {
+                                    logger.debug('waiting for validationRequest');
                                     window.setTimeout(checkValidationRequest, 100);
+                                } else {
+                                    logger.debug('end of wait for validationRequest');
                                 }
                             }
                             checkValidationRequest();

--- a/lib/services/validation.js
+++ b/lib/services/validation.js
@@ -212,7 +212,7 @@ function validationProcess(req, res, next) {
         if (error) {
             logger.debug('error: trying next');
         } else if (value === 'Permit') {
-            logger.debug('Request access accepted');
+            logger.debug('Request access accepted in bucle');
             next(null, 'Permit');
         } else {
             logger.debug('Request access denied: trying next');
@@ -244,6 +244,7 @@ function validationProcess(req, res, next) {
                         // Validate it
                         validationRequest(req.roles, req.frn, req.action,
                                           req.headers, handleBucleValidation);
+                        logger.debug('validated with  %s', newSubservice);
                     } else {
                         logger.debug('error authorization process in subservice %s',
                                      newSubservice);
@@ -251,6 +252,7 @@ function validationProcess(req, res, next) {
                 });
 
             } // for
+            logger.debug('end bucle validating  %s', newSubservice);
             req.subService = subservice;
             next(new errors.RolesNotFound(req.subService));
         } else {


### PR DESCRIPTION
Motto: If a requrest is denied for a subservice like /level1/level2/level3 but user has permission over /level1 or /level1/level2 then request is accepted.

Currently PEP follows this secuence:
- Get request action service/subservice
- Get Roles of user in service/subservice
- Check roles with action in service/subservice

This new proposal makes a loop over possible service/subservice
  - Get Roles of user in new service/subservice
  - Check roles with action new service/subservice

Issue https://github.com/telefonicaid/fiware-pep-steelskin/issues/414
- [x] Configuration option flag
- [ ] Tested