### PR TITLE
Support actionType: replace (along with some other related improvements)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 - ADD version to orion urls as read action [#416]
 - Upgrade from node:8.12.0-slim to node:8.16.0-slim as base image in Dockerfile
 - Add: access control disabled flag as config environment variable (for docker)
+- Support REPLACE (NGSIv1), replace (NGSIv2) and appendStrict (NGSIv2) as action type for ContextBroker requests (#422).

--- a/README.md
+++ b/README.md
@@ -605,9 +605,9 @@ This is the list of actions available for the Context Broker. For every action, 
 | N/A | - |
 
 ### Standard operations
-* `create`: URL contains `/v1/updateContext` and the `actionType` attribute of the payload (either with XML or JSON) is `APPEND`.
-* `update`: URL contains `/v1/updateContext` and the `actionType` attribute of the payload (either with XML or JSON) is `UPDATE`.
-* `delete`: URL contains `/v1/updateContext` and the `actionType` attribute of the payload (either with XML or JSON) is “DELETE”.
+* `create`: URL contains `/v1/updateContext` and the `actionType` attribute of the payload (either with XML or JSON) is `APPEND` or `APPEND_STRICT`.
+* `update`: URL contains `/v1/updateContext` and the `actionType` attribute of the payload (either with XML or JSON) is `UPDATE` or `REPLACE`.
+* `delete`: URL contains `/v1/updateContext` and the `actionType` attribute of the payload (either with XML or JSON) is `DELETE`.
 * `read`: URL contains `/v1/queryContext` or `/v1/contextTypes`.
 * `subscribe`: URL contains  `/v1/subscribeContext`, `/v1/updateContextSubscription` o `/v1/unsubscribeContext`.
 * `register`: URL contains `/v1/registry/registerContext`.
@@ -705,10 +705,11 @@ An up-to-date list of the convenience operations can be found [here](https://doc
 
 (*) It depends on the `actionType` (within payload):
 
-* UPDATE: U
-* APPEND: C
-* APPEND_STRICT: C
-* DELETE: D
+* update: U
+* append: C
+* appendStrict: C
+* delete: D
+* replace: U
 
 Operations marked with a slash, "-" are now deprecated. All those operations will be tagged with the special action "N/A". If you want to allow them anyway, just add a rule to the Access Control allowing the "N/A" action for the desired roles.
 

--- a/lib/plugins/orionPlugin.js
+++ b/lib/plugins/orionPlugin.js
@@ -38,21 +38,25 @@ var sax = require('sax'),
 function translateAction(originalAction) {
     var action;
 
-    switch (originalAction.toUpperCase()) {
-        case 'APPEND':
+    switch (originalAction.toLowerCase()) {
+        case 'append':
             action = 'create';
             break;
 
-        case 'APPEND_STRICT':
+        case 'appendstrict':
             action = 'create';
             break;
 
-        case 'UPDATE':
+        case 'update':
             action = 'update';
             break;
 
-        case 'DELETE':
+        case 'delete':
             action = 'delete';
+            break;
+
+        case 'replace':
+            action = 'update';
             break;
 
         default:

--- a/lib/plugins/orionPlugin.js
+++ b/lib/plugins/orionPlugin.js
@@ -43,7 +43,11 @@ function translateAction(originalAction) {
             action = 'create';
             break;
 
-        case 'appendstrict':
+        case 'append_strict':  // NGSIv1
+            action = 'create';
+            break;
+            
+        case 'appendstrict': // NGSIv2
             action = 'create';
             break;
 

--- a/test/unit/extract_csb_actions_test.js
+++ b/test/unit/extract_csb_actions_test.js
@@ -613,10 +613,11 @@ describe('Extract Context Broker action from request', function() {
     });
 
     var v2UpdateOperationMatrix = [
-        ['APPEND', 'create'],
-        ['APPEND_STRICT', 'create'],
-        ['UPDATE', 'update'],
-        ['DELETE', 'delete']
+        ['append', 'create'],
+        ['appendStrict', 'create'],
+        ['update', 'update'],
+        ['delete', 'delete'],
+        ['replace', 'update']
     ];
 
     function testV2updateAction(index) {


### PR DESCRIPTION
Some minor fixes have been proposed in orionPlugin.js :
1. Include the actionType "replace" (see https://fiware-orion.readthedocs.io/en/master/user/update_action_types/index.html).
2. Invert the logic to work with lowercases in order to be more aligned with NGSIv2.
3. NGSIv2 uses "appendStrict" instead of "append_strict".

Commit: 891c663