### PR TITLE
fix debug log about KEYSTONE_AUTHENTICATION_REJECTED

### DIFF
--- a/lib/services/keystoneAuth.js
+++ b/lib/services/keystoneAuth.js
@@ -539,7 +539,11 @@ function authenticationProcess(req, res, next) {
             attempts++;
             process.nextTick(processFlow.bind(null, retry));
         } else if (error) {
-            logger.error('[VALIDATION-GEN-003] Error connecting to Keystone authentication: %s', error);
+            if (error.name === 'KEYSTONE_AUTHENTICATION_REJECTED') {
+                logger.debug('Authentication failed: %s', error);
+            } else {
+                logger.error('[VALIDATION-GEN-003] Error connecting to Keystone authentication: %s', error);
+            }
             next(error);
         } else {
             logger.debug('Authentication success after %d attempts', attempts);


### PR DESCRIPTION
Continues from previous PR https://github.com/telefonicaid/fiware-pep-steelskin/pull/440

This logs happens when user provides to PEP a non valid or expired token