### PR TITLE
check 401 status response before body content in retrieveSubserviceId

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+- Check 401 status response before body content in retrieveSubserviceId
 - Set Nodejs 10 as minimum version in packages.json (effectively removing Nodev8 from supported versions)

--- a/lib/services/keystoneAuth.js
+++ b/lib/services/keystoneAuth.js
@@ -341,13 +341,13 @@ function retrieveSubserviceId(req, callback) {
 
                 logger.error('Error connecting Keystone for subservice ID retrieving: %s', message);
                 innerCb(new errors.KeystoneAuthenticationError(message));
-            } else if (!body || !body.projects || body.projects.length === 0) {
-                logger.error('Couldn\'t find subservice id in Keystone with name %s', subserviceName);
-                innerCb(new errors.KeystoneSubserviceNotFound(subserviceName));
             } else if (response.statusCode === 401) {
                 logger.debug('Invalid PEP Proxy token found: %s', currentToken);
                 currentToken = null; // Force ask new PEP token next retry attempt
                 innerCb(new errors.PepProxyAuthenticationRejected(401));
+            } else if (!body || !body.projects || body.projects.length === 0) {
+                logger.error('Couldn\'t find subservice id in Keystone with name %s', subserviceName);
+                innerCb(new errors.KeystoneSubserviceNotFound(subserviceName));
             } else if (response.statusCode === 200) {
                 var project;
 


### PR DESCRIPTION
And avoid a false error like this log:
```
time=2020-07-27T05:15:17.203Z | lvl=ERROR | corr=821b4e2d-27a5-4cba-9ec5-20d1db401634 | trans=821b4e2d-27a5-4cba-9ec5-20d1db401634 | op=/v2/entities/poi_1/attrs | srv=sc_vlci | subsrv=/wifi | msg=[VALIDATION-GEN-003] Error connecting to Keystone authentication: KEYSTONE_SUBSERVICE_NOT_FOUND: Could not find subservice with name [/wifi] in Keystone. | comp=PEPorion
```