### PR TITLE
log value cache properly

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Add: print object detail in debug logs about cache
 - Remove: availability subscription related actions in Orion plugin
 - BUG not logrotate logs of PEP in deploy no Docker #457
 

--- a/lib/services/cacheUtils.js
+++ b/lib/services/cacheUtils.js
@@ -88,7 +88,7 @@ function createDomainEnabledCacheHandler(domain, processValueFn, cache, cacheTyp
             var currentValue = cache.data[cacheType].get(cacheKey)[cacheKey] || value;
 
             domain.enter();
-            logger.debug('Value found for cache type [%s] key [%s]: %s', cacheType, cacheKey, value);
+            logger.debug('Value found for cache type [%s] key [%s]: %j', cacheType, cacheKey, value);
             logger.debug('Processing with value: %s', JSON.stringify(cache.data[cacheType].get(cacheKey)[cacheKey]));
 
             processValueFn(currentValue, callback);
@@ -144,7 +144,7 @@ function cacheAndHold(cacheType, cacheKey, retrieveRequestFn, processValueFn, ca
         ));
 
         retrieveRequestFn(function(error, value) {
-            logger.debug('Value [%s] for type [%s] processed with value: %s.', cacheKey, cacheType, value);
+            logger.debug('Value [%s] for type [%s] processed with value: %j.', cacheKey, cacheType, value);
 
             cache.channel.emit(getCacheEventId(), error, value);
             cache.channel.removeAllListeners(getCacheEventId());


### PR DESCRIPTION
to avoid print logs with `[object]` instead real value