### PR TITLE
check properly content-type

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -3,4 +3,4 @@
 - Upgrade requests dep from 2.88.0 to 2.88.2
 - Fix: propagate correlator in FWD request (#468)
 - Fix: propagate correlator in validation (Access Control) requests
-- Fix: check properly content-type of request
+- Fix: request log properly, based in its content-type

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,3 +2,4 @@
 - Fix: upgrade underscore dep from 1.7.0 to 1.12.1
 - Upgrade requests dep from 2.88.0 to 2.88.2
 - Fix: propagate correlator in FWD request (#468)
+- Fix: check properly content-type of request

--- a/lib/fiware-pep-steelskin.js
+++ b/lib/fiware-pep-steelskin.js
@@ -200,12 +200,16 @@ function traceRequest(req, res, next) {
     logger.debug('Request for path [%s] from [%s]', req.path, req.get('host'));
     logger.debug('Headers:\n%j\n', req.headers);
 
-    if (req.headers['content-type'] === 'application/json') {
-        logger.debug('Body:\n\n%s\n\n', JSON.stringify(req.body, null, 4));
-    } else if (req.headers['content-type'] === 'application/xml') {
-        logger.debug('Body:\n\n%s\n\n', req.rawBody);
+    if (req.headers['content-type']) {
+        if (req.headers['content-type'].includes('application/json')) {
+            logger.debug('Body:\n\n%s\n\n', JSON.stringify(req.body, null, 4));
+        } else if (req.headers['content-type'].includes('application/xml')) {
+            logger.debug('Body:\n\n%s\n\n', req.rawBody);
+        } else {
+            logger.debug('Unrecognized body type', req.headers['content-type']);
+        }
     } else {
-        logger.debug('Unrecognized body type', req.headers['content-type']);
+        logger.debug('Not found body type');
     }
 
     next();

--- a/lib/fiware-pep-steelskin.js
+++ b/lib/fiware-pep-steelskin.js
@@ -203,7 +203,8 @@ function traceRequest(req, res, next) {
     if (req.headers['content-type'] && req.headers['content-type'] !== undefined) {
         if (req.headers['content-type'].includes('application/json')) {
             logger.debug('Body:\n\n%s\n\n', JSON.stringify(req.body, null, 4));
-        } else if (req.headers['content-type'].includes('application/xml')) {
+        } else if ( req.headers['content-type'].includes('application/xml') ||
+                    req.headers['content-type'].includes('text/plain') ) {
             logger.debug('Body:\n\n%s\n\n', req.rawBody);
         } else {
             logger.debug('Unrecognized body type', req.headers['content-type']);

--- a/lib/fiware-pep-steelskin.js
+++ b/lib/fiware-pep-steelskin.js
@@ -200,7 +200,7 @@ function traceRequest(req, res, next) {
     logger.debug('Request for path [%s] from [%s]', req.path, req.get('host'));
     logger.debug('Headers:\n%j\n', req.headers);
 
-    if (req.headers['content-type']) {
+    if (req.headers['content-type'] && req.headers['content-type'] !== undefined) {
         if (req.headers['content-type'].includes('application/json')) {
             logger.debug('Body:\n\n%s\n\n', JSON.stringify(req.body, null, 4));
         } else if (req.headers['content-type'].includes('application/xml')) {


### PR DESCRIPTION
most of the times content-type is something like: `application/json; utf-8` which was detected as unknown content-type
As a result of then a log with a false failure was printed.