### PR TITLE
Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "async": "0.9.0",
     "express": "4.16.4",
     "body-parser": "1.18.3",
-    "logops": "2.1.0",
+    "logops": "2.1.2",
     "mustache": "2.2.1",
     "node-cache": "1.0.3",
     "request": "2.88.2",


### PR DESCRIPTION
logops < 2.1.2 depends on colors dependency, which recently have a corruption problem: https://snyk.io/blog/open-source-npm-packages-colors-faker/
