### PR TITLE
upgrade express dep version from 4.16 to 4.18.1

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
+- Upgrade express dep from 4.16.4 to 4.18.1
 - Fix: Dockerfile to include initial packages upgrade
 - Set Nodejs 12 as minimum version in packages.json (effectively removing Nodev10 from supported versions)

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "async": "0.9.0",
-    "express": "4.16.4",
+    "express": "4.18.1",
     "body-parser": "1.18.3",
     "logops": "2.1.2",
     "mustache": "2.2.1",


### PR DESCRIPTION
- [x] Tested
https://github.com/expressjs/express/releases

4.16.4 where released in 2018