### PR TITLE
upgrade async dep from 0.9.0 to 2.6.4

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
 - Upgrade express dep from 4.16.4 to 4.18.1
+- Upgrade async dep from 0.9.0 to 2.6.4 
 - Fix: Dockerfile to include initial packages upgrade
 - Set Nodejs 12 as minimum version in packages.json (effectively removing Nodev10 from supported versions)
-- Upgrade async dep from 0.9.0 to 2.6.4 

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - Fix: Dockerfile to include initial packages upgrade
 - Set Nodejs 12 as minimum version in packages.json (effectively removing Nodev10 from supported versions)
+- Upgrade async dep from 0.9.0 to 2.6.4 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "watch": "watch 'npm test && npm run lint' ./lib ./test"
   },
   "dependencies": {
-    "async": "0.9.0",
+    "async": "2.6.4",
     "express": "4.16.4",
     "body-parser": "1.18.3",
     "logops": "2.1.2",


### PR DESCRIPTION
- [x] Tested.
Only apply method is used from async.