### PR TITLE
Upgrade body-paser from 1.18.3 to 1.20.0

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-- Upgrade body-paser dep from 1.18.3 to 1.20.0
+- Upgrade body-parser dep from 1.18.3 to 1.20.0
 - Upgrade express dep from 4.16.4 to 4.18.1
 - Upgrade async dep from 0.9.0 to 2.6.4 
 - Fix: Dockerfile to include initial packages upgrade

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Upgrade body-paser from 1.18.3 to 1.20.0
 - Upgrade express dep from 4.16.4 to 4.18.1
 - Upgrade async dep from 0.9.0 to 2.6.4 
 - Fix: Dockerfile to include initial packages upgrade

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-- Upgrade body-paser from 1.18.3 to 1.20.0
+- Upgrade body-paser dep from 1.18.3 to 1.20.0
 - Upgrade express dep from 4.16.4 to 4.18.1
 - Upgrade async dep from 0.9.0 to 2.6.4 
 - Fix: Dockerfile to include initial packages upgrade

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "async": "2.6.4",
     "express": "4.18.1",
-    "body-parser": "1.18.3",
+    "body-parser": "1.20.0",
     "logops": "2.1.2",
     "mustache": "2.2.1",
     "node-cache": "1.0.3",


### PR DESCRIPTION
body parser versions: https://github.com/expressjs/body-parser/releases
Gap cover sub deps upgrades