### PR TITLE
upgrade to node-cache 5.1.2

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Upgrade node-acache dep from 1.1.3 to 5.1.2
 - Upgrade body-parser dep from 1.18.3 to 1.20.0
 - Upgrade express dep from 4.16.4 to 4.18.1
 - Upgrade async dep from 0.9.0 to 2.6.4 

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-- Upgrade node-acache dep from 1.1.3 to 5.1.2
+- Upgrade node-acache dep from 1.0.3 to 5.1.2
 - Upgrade body-parser dep from 1.18.3 to 1.20.0
 - Upgrade express dep from 4.16.4 to 4.18.1
 - Upgrade async dep from 0.9.0 to 2.6.4 

--- a/lib/services/cacheUtils.js
+++ b/lib/services/cacheUtils.js
@@ -85,11 +85,11 @@ function createDomainEnabledCacheHandler(domain, processValueFn, cache, cacheTyp
             logger.debug('Error found creating cache domain handler');
             callback(error);
         } else {
-            var currentValue = cache.data[cacheType].get(cacheKey)[cacheKey] || value;
+            var currentValue = cache.data[cacheType].get(cacheKey) || value;
 
             domain.enter();
             logger.debug('Value found for cache type [%s] key [%s]: %j', cacheType, cacheKey, value);
-            logger.debug('Processing with value: %s', JSON.stringify(cache.data[cacheType].get(cacheKey)[cacheKey]));
+            logger.debug('Processing with value: %s', JSON.stringify(cache.data[cacheType].get(cacheKey)));
 
             processValueFn(currentValue, callback);
         }
@@ -114,10 +114,10 @@ function cacheAndHold(cacheType, cacheKey, retrieveRequestFn, processValueFn, ca
         return cacheType + ':' + cacheKey;
     }
 
-    if (cachedValue[cacheKey]) {
-        logger.debug('Value found in the cache [%s] for key [%s]: %s', cacheType, cacheKey, cachedValue[cacheKey]);
+    if (cachedValue) {
+        logger.debug('Value found in the cache [%s] for key [%s]: %s', cacheType, cacheKey, cachedValue);
 
-        processValueFn(cachedValue[cacheKey], callback);
+        processValueFn(cachedValue, callback);
     } else if (cache.updating[cacheType][cacheKey]) {
         logger.debug('Cache type [%s] updating for key [%s]. Waiting.', cacheType, cacheKey);
 

--- a/lib/services/cacheUtils.js
+++ b/lib/services/cacheUtils.js
@@ -40,16 +40,24 @@ function createCache() {
     cache = {
         data: {
             subservice: new NodeCache({
-                stdTTL: config.authentication.cacheTTLs.projectIds
+                stdTTL: config.authentication.cacheTTLs.projectIds,
+                useClones: false, // keep backward compatibility with node-cache 2.0.0 and previous
+                enableLegacyCallbacks: true // keep backward compatibility with node-cache 4.0.0 and previous
             }),
             roles: new NodeCache({
-                stdTTL: config.authentication.cacheTTLs.roles
+                stdTTL: config.authentication.cacheTTLs.roles,
+                useClones: false,
+                enableLegacyCallbacks: true
             }),
             user: new NodeCache({
-                stdTTL: config.authentication.cacheTTLs.users
+                stdTTL: config.authentication.cacheTTLs.users,
+                useClones: false,
+                enableLegacyCallbacks: true
             }),
             validation: new NodeCache({
-                stdTTL: config.authentication.cacheTTLs.validation
+                stdTTL: config.authentication.cacheTTLs.validation,
+                useClones: false,
+                enableLegacyCallbacks: true
             })
         },
         channel: cacheChannel,
@@ -65,16 +73,24 @@ function createCache() {
 function cleanCache() {
     if (cache && cache.data) {
         cache.data.user = new NodeCache({
-            stdTTL: config.authentication.cacheTTLs.users
+            stdTTL: config.authentication.cacheTTLs.users,
+            useClones: false,
+            enableLegacyCallbacks: true
         });
         cache.data.subservice = new NodeCache({
-            stdTTL: config.authentication.cacheTTLs.projectIds
+            stdTTL: config.authentication.cacheTTLs.projectIds,
+            useClones: false,
+            enableLegacyCallbacks: true
         });
         cache.data.roles = new NodeCache({
-            stdTTL: config.authentication.cacheTTLs.roles
+            stdTTL: config.authentication.cacheTTLs.roles,
+            useClones: false,
+            enableLegacyCallbacks: true
         });
         cache.data.validation = new NodeCache({
-            stdTTL: config.authentication.cacheTTLs.validation
+            stdTTL: config.authentication.cacheTTLs.validation,
+            useClones: false,
+            enableLegacyCallbacks: true
         });
     }
 }

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   },
   "dependencies": {
     "async": "2.6.4",
-    "express": "4.18.1",
     "body-parser": "1.18.3",
+    "express": "4.18.1",
     "logops": "2.1.2",
     "mustache": "2.2.1",
-    "node-cache": "1.0.3",
+    "node-cache": "2.1.1",
     "request": "2.88.2",
     "sax": "0.6.0",
     "underscore": "1.12.1",
@@ -40,12 +40,12 @@
     "winston": "~2.3.1"
   },
   "devDependencies": {
-    "mocha": "5.2.0",
     "istanbul": "0.4.5",
+    "jshint": "~2.9.6",
+    "mocha": "5.2.0",
+    "nock": "9.0.14",
     "proxyquire": "0.5.1",
     "should": "8.4.0",
-    "nock": "9.0.14",
-    "jshint": "~2.9.6",
     "watch": "~1.0.2"
   },
   "keywords": []

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "express": "4.18.1",
     "logops": "2.1.2",
     "mustache": "2.2.1",
-    "node-cache": "4.2.1",
+    "node-cache": "5.1.2",
     "request": "2.88.2",
     "sax": "0.6.0",
     "uuid": "~3.0.0",

--- a/package.json
+++ b/package.json
@@ -32,10 +32,9 @@
     "express": "4.18.1",
     "logops": "2.1.2",
     "mustache": "2.2.1",
-    "node-cache": "2.1.1",
+    "node-cache": "5.1.2",
     "request": "2.88.2",
     "sax": "0.6.0",
-    "underscore": "1.12.1",
     "uuid": "~3.0.0",
     "winston": "~2.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "express": "4.18.1",
     "logops": "2.1.2",
     "mustache": "2.2.1",
-    "node-cache": "3.2.1",
+    "node-cache": "4.2.1",
     "request": "2.88.2",
     "sax": "0.6.0",
     "uuid": "~3.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "express": "4.18.1",
     "logops": "2.1.2",
     "mustache": "2.2.1",
-    "node-cache": "5.1.2",
+    "node-cache": "3.2.1",
     "request": "2.88.2",
     "sax": "0.6.0",
     "uuid": "~3.0.0",


### PR DESCRIPTION
https://www.npmjs.com/package/node-cache

2.0+ node-cache version has improvements of 300+ times in get access, but changes .get API:

`
2.0.0 | 2015-01-05 | changed return format of .get() with a error return on a miss and added the .mget() method. Side effect: Performance of .get() up to 330 times faster!
`

And also there a re bugfixing about ttl expiration...
