### PR TITLE
add API to get cache stats

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-- Add: new API to retrieve cache stats
+- Add: new API to retrieve cache stats (GET /admin/cacheStats)
 - Upgrade uuid dep from ~3.0.0 to 8.3.2 
 - Upgrade sax dep from 0.6.0 to 1.2.4
 - Upgrade body-parser dep from 1.18.3 to 1.20.0

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Add: new API to retrieve cache stats
 - Upgrade sax dep from 0.6.0 to 1.2.4
 - Upgrade body-parser dep from 1.18.3 to 1.20.0
 - Upgrade express dep from 4.16.4 to 4.18.1

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,5 @@
 - Add: new API to retrieve and reset cache stats (GET, DELETE /admin/cacheStats)
+- Add: new API to reset cache (DELETE /admin/cache)
 - Upgrade node-acache dep from 1.0.3 to 5.1.2
 - Upgrade uuid dep from ~3.0.0 to 8.3.2 
 - Upgrade sax dep from 0.6.0 to 1.2.4

--- a/lib/middleware/administration.js
+++ b/lib/middleware/administration.js
@@ -87,7 +87,7 @@ function resetCacheStats(req, res, next) {
     cacheUtils.get().data.roles.flushStats();
     cacheUtils.get().data.user.flushStats();
     cacheUtils.get().data.validation.flushStats();
-    res.status(204);
+    res.status(204).json({});
 }
 
 

--- a/lib/middleware/administration.js
+++ b/lib/middleware/administration.js
@@ -52,6 +52,7 @@ function changeLogLevel(req, res, next) {
             newLevel = 'WARN';
         }
         logger.setLevel(newLevel);
+        logger.info('change log level to ' + newLevel);
         res.status(200).send('');
     }
 }
@@ -83,10 +84,21 @@ function getCacheStats(req, res, next) {
  * Reset the cache statistics
  */
 function resetCacheStats(req, res, next) {
+    logger.info('reset cache stats ');
     cacheUtils.get().data.subservice.flushStats();
     cacheUtils.get().data.roles.flushStats();
     cacheUtils.get().data.user.flushStats();
     cacheUtils.get().data.validation.flushStats();
+    res.status(204).json({});
+}
+
+
+function resetCache(req, res, next) {
+    logger.info('reset cache');
+    cacheUtils.get().data.subservice.flushAll();
+    cacheUtils.get().data.roles.flushAll();
+    cacheUtils.get().data.user.flushAll();
+    cacheUtils.get().data.validation.flushAll();
     res.status(204).json({});
 }
 
@@ -97,6 +109,7 @@ function loadContextRoutes(router) {
     router.get('/admin/log', getLogLevel);
     router.get('/admin/cacheStats', getCacheStats);
     router.delete('/admin/cacheStats', resetCacheStats);
+    router.delete('/admin/cache', resetCache);
 }
 
 exports.loadContextRoutes = loadContextRoutes;

--- a/lib/middleware/administration.js
+++ b/lib/middleware/administration.js
@@ -79,12 +79,24 @@ function getCacheStats(req, res, next) {
     });
 }
 
+/**
+ * Reset the cache statistics
+ */
+function resetCacheStats(req, res, next) {
+    cacheUtils.get().data.subservice.flushAll();
+    cacheUtils.get().data.roles.flushAll();
+    cacheUtils.get().data.user.flushAll();
+    cacheUtils.get().data.validation.flushAll();
+    res.status(204);
+}
+
 
 function loadContextRoutes(router) {
     router.get('/version', retrieveVersion);
     router.put('/admin/log', changeLogLevel);
     router.get('/admin/log', getLogLevel);
     router.get('/admin/cacheStats', getCacheStats);
+    router.delete('/admin/cacheStats', resetCacheStats);
 }
 
 exports.loadContextRoutes = loadContextRoutes;

--- a/lib/middleware/administration.js
+++ b/lib/middleware/administration.js
@@ -25,7 +25,8 @@
 
 var packageInformation = require('../../package.json'),
     config = require('../../config'),
-    logger = require('logops');
+    logger = require('logops'),
+    cacheUtils = require('./../services/cacheUtils');
 
 function retrieveVersion(req, res, next) {
     res.status(200).json({
@@ -64,10 +65,26 @@ function getLogLevel(req, res, next) {
     });
 }
 
+/**
+ * Return the cache statistics
+ */
+function getCacheStats(req, res, next) {
+    res.status(200).json({
+        stats: {
+            subservice: cacheUtils.get().data.subservice.getStats(),
+            roles: cacheUtils.get().data.roles.getStats(),
+            user: cacheUtils.get().data.user.getStats(),
+            validation: cacheUtils.get().data.validation.getStats()
+        }
+    });
+}
+
+
 function loadContextRoutes(router) {
     router.get('/version', retrieveVersion);
     router.put('/admin/log', changeLogLevel);
     router.get('/admin/log', getLogLevel);
+    router.get('/admin/stats', getCacheStats);    
 }
 
 exports.loadContextRoutes = loadContextRoutes;

--- a/lib/middleware/administration.js
+++ b/lib/middleware/administration.js
@@ -70,7 +70,7 @@ function getLogLevel(req, res, next) {
  */
 function getCacheStats(req, res, next) {
     res.status(200).json({
-        stats: {
+        cacheStats: {
             subservice: cacheUtils.get().data.subservice.getStats(),
             roles: cacheUtils.get().data.roles.getStats(),
             user: cacheUtils.get().data.user.getStats(),
@@ -84,7 +84,7 @@ function loadContextRoutes(router) {
     router.get('/version', retrieveVersion);
     router.put('/admin/log', changeLogLevel);
     router.get('/admin/log', getLogLevel);
-    router.get('/admin/stats', getCacheStats);    
+    router.get('/admin/cacheStats', getCacheStats);
 }
 
 exports.loadContextRoutes = loadContextRoutes;

--- a/lib/middleware/administration.js
+++ b/lib/middleware/administration.js
@@ -83,10 +83,10 @@ function getCacheStats(req, res, next) {
  * Reset the cache statistics
  */
 function resetCacheStats(req, res, next) {
-    cacheUtils.get().data.subservice.flushAll();
-    cacheUtils.get().data.roles.flushAll();
-    cacheUtils.get().data.user.flushAll();
-    cacheUtils.get().data.validation.flushAll();
+    cacheUtils.get().data.subservice.flushStats();
+    cacheUtils.get().data.roles.flushStats();
+    cacheUtils.get().data.user.flushStats();
+    cacheUtils.get().data.validation.flushStats();
     res.status(204);
 }
 

--- a/operations.md
+++ b/operations.md
@@ -26,7 +26,7 @@ curl -X GET "http://localhost:11211/admin/log"
 
 Every error message is identified with a prefix code in brackets. The code convention can be found in Apendix A.
 
-## ## <a name="Cache Stats"/> Cache Stats
+## <a name="Cache Stats"/> Cache Stats
 
 PEP keeps a memory cache with some access about roles, domains, users and subservices. Related with this info is possible
 get an statistics about these caches using the following API:

--- a/operations.md
+++ b/operations.md
@@ -40,6 +40,13 @@ Getting
 {"cacheStats":{"subservice":{"hits":0,"misses":0,"keys":0,"ksize":0,"vsize":0},"roles":{"hits":9,"misses":1,"keys":0,"ksize":0,"vsize":0},"user":{"hits":9,"misses":2,"keys":1,"ksize":183,"vsize":240},"validation":{"hits":9,"misses":1,"keys":0,"ksize":0,"vsize":0}}}
 ```
 
+And also it is possible reset stats:
+
+```
+curl -X DELETE "http://localhost:11211/admin/cacheStats"
+```
+
+
 ## Fatal errors
 The following sections list all the critical errors that may completely stop the service.
 ### Validation errors

--- a/operations.md
+++ b/operations.md
@@ -36,11 +36,9 @@ curl -X GET "http://localhost:11211/admin/cacheStats"
 ```
 Getting
 
-`json
+```json
 {"cacheStats":{"subservice":{"hits":0,"misses":0,"keys":0,"ksize":0,"vsize":0},"roles":{"hits":9,"misses":1,"keys":0,"ksize":0,"vsize":0},"user":{"hits":9,"misses":2,"keys":1,"ksize":183,"vsize":240},"validation":{"hits":9,"misses":1,"keys":0,"ksize":0,"vsize":0}}}
-`
-
-
+```
 
 ## Fatal errors
 The following sections list all the critical errors that may completely stop the service.

--- a/operations.md
+++ b/operations.md
@@ -40,10 +40,16 @@ Getting
 {"cacheStats":{"subservice":{"hits":0,"misses":0,"keys":0,"ksize":0,"vsize":0},"roles":{"hits":9,"misses":1,"keys":0,"ksize":0,"vsize":0},"user":{"hits":9,"misses":2,"keys":1,"ksize":183,"vsize":240},"validation":{"hits":9,"misses":1,"keys":0,"ksize":0,"vsize":0}}}
 ```
 
-And also it is possible reset stats:
+And also it is possible reset cache stats:
 
 ```
 curl -X DELETE "http://localhost:11211/admin/cacheStats"
+```
+
+And reset full cache (data and stats):
+
+```
+curl -X DELETE "http://localhost:11211/admin/cache"
 ```
 
 

--- a/operations.md
+++ b/operations.md
@@ -2,7 +2,7 @@
 ## Index
 
 * [Logs](#logs)
-* [Cache Stats](#stats)
+* [Cache management](#cache)
 * [Expected problems and known solutions](#problems)
 * [Error naming code](#errorcode)
 

--- a/operations.md
+++ b/operations.md
@@ -26,7 +26,7 @@ curl -X GET "http://localhost:11211/admin/log"
 
 Every error message is identified with a prefix code in brackets. The code convention can be found in Apendix A.
 
-## <a name="Cache Stats"/> Cache Stats
+## <a name="cache"/> Cache management
 
 PEP keeps a memory cache with some access about roles, domains, users and subservices. Related with this info is possible
 get an statistics about these caches using the following API:

--- a/operations.md
+++ b/operations.md
@@ -1,7 +1,8 @@
-# Operations Manual: logs and alarms
+# Operations Manual: logs, alarms and stats
 ## Index
 
 * [Logs](#logs)
+* [Cache Stats](#stats)
 * [Expected problems and known solutions](#problems)
 * [Error naming code](#errorcode)
 
@@ -24,6 +25,22 @@ curl -X GET "http://localhost:11211/admin/log"
 ```
 
 Every error message is identified with a prefix code in brackets. The code convention can be found in Apendix A.
+
+## ## <a name="Cache Stats"/> Cache Stats
+
+PEP keeps a memory cache with some access about roles, domains, users and subservices. Related with this info is possible
+get an statistics about these caches using the following API:
+
+```
+curl -X GET "http://localhost:11211/admin/cacheStats"
+```
+Getting
+
+`json
+{"cacheStats":{"subservice":{"hits":0,"misses":0,"keys":0,"ksize":0,"vsize":0},"roles":{"hits":9,"misses":1,"keys":0,"ksize":0,"vsize":0},"user":{"hits":9,"misses":2,"keys":1,"ksize":183,"vsize":240},"validation":{"hits":9,"misses":1,"keys":0,"ksize":0,"vsize":0}}}
+`
+
+
 
 ## Fatal errors
 The following sections list all the critical errors that may completely stop the service.

--- a/test/unit/cacheStats_api-test.js
+++ b/test/unit/cacheStats_api-test.js
@@ -100,4 +100,25 @@ describe('Cache Stats API', function() {
         });
     });
 
+    describe('When the current cache is reset through the API', function() {
+        var options = {
+            uri: 'http://localhost:' + config.resource.proxy.adminPort + '/admin/cache',
+            method: 'DELETE',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+            }
+        };
+
+        it('should return a 204 code', function(done) {
+            request(options, function(error, response, body) {
+                should.not.exist(error);
+                response.statusCode.should.equal(204);
+
+                done();
+            });
+        });
+    });
+
+
 });

--- a/test/unit/cacheStats_api-test.js
+++ b/test/unit/cacheStats_api-test.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2014 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-pep-steelskin
+ *
+ * fiware-pep-steelskin is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * fiware-pep-steelskin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with fiware-pep-steelskin.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[daniel.moranjimenez@telefonica.com]
+ */
+
+'use strict';
+
+var should = require('should'),
+    proxyLib = require('../../lib/fiware-pep-steelskin'),
+    config = require('../../config'),
+    request = require('request'),
+    logger = require('logops');
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+describe('Cache Stats API', function() {
+    var proxy;
+
+    beforeEach(function(done) {
+        logger.setLevel('FATAL');
+
+        proxyLib.start(function(error, proxyObj) {
+            proxy = proxyObj;
+            done();
+        });
+    });
+
+    afterEach(function(done) {
+        logger.setLevel('FATAL');
+
+        config.ssl.active = false;
+        proxyLib.stop(proxy, done);
+    });
+
+    describe('When the current cache stats is requested through the API', function() {
+        var options = {
+            uri: 'http://localhost:' + config.resource.proxy.adminPort + '/admin/cacheStats',
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+            }
+        };
+
+        it('should return a 200 OK', function(done) {
+            request(options, function(error, response, body) {
+                should.not.exist(error);
+                response.statusCode.should.equal(200);
+
+                done();
+            });
+        });
+
+        it('should return the current cache stats', function(done) {
+            request(options, function(error, response, body) {
+                var parsedBody = JSON.parse(body);
+
+                should.exist(parsedBody.cacheStats);
+                done();
+            });
+        });
+    });
+
+});

--- a/test/unit/cacheStats_api-test.js
+++ b/test/unit/cacheStats_api-test.js
@@ -79,4 +79,25 @@ describe('Cache Stats API', function() {
         });
     });
 
+
+    describe('When the current cache stats is reset through the API', function() {
+        var options = {
+            uri: 'http://localhost:' + config.resource.proxy.adminPort + '/admin/cacheStats',
+            method: 'DELETE',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+            }
+        };
+
+        it('should return a 204 code', function(done) {
+            request(options, function(error, response, body) {
+                should.not.exist(error);
+                response.statusCode.should.equal(204);
+
+                done();
+            });
+        });
+    });
+
 });


### PR DESCRIPTION
Based on node-cache stats API

API to get info about node cache stats:
https://github.com/node-cache/node-cache#statistics-stats

curl -i -X GET http://localhost:11211/admin/cacheStats
HTTP/1.1 200 OK
X-Powered-By: Express
fiware-correlator: 6386f32a-3f5f-4f57-8b05-813ce3ed6607
Content-Type: application/json; charset=utf-8
Content-Length: 265
ETag: W/"109-JPQLnurOZTITjopfP0LhKQSKm7A"
Date: Wed, 18 May 2022 11:17:41 GMT
Connection: keep-alive
Keep-Alive: timeout=5

{"cacheSats":{"subservice":{"hits":0,"misses":0,"keys":0,"ksize":0,"vsize":0},"roles":{"hits":9,"misses":1,"keys":1,"ksize":34,"vsize":200},"user":{"hits":9,"misses":2,"keys":1,"ksize":183,"vsize":240},"validation":{"hits":9,"misses":1,"keys":1,"ksize":197,"vsize":6}}}