### PR TITLE
Task/add access matches (about users, headers, path. .. ) to access Logger

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,5 +1,6 @@
 - Add User name, request path, query and body to AccessLogger (#541)
 - Ensure Origin of AccesLogger show x-forwarderd-for header if exists
 - Add Access Logger Patterns to match to Access Logger (#541)
+- Homogenizes format for Access Logger with pep logs
 - Upgrade body-parser dep from 1.20.0 to 1.20.3
 - Upgrade express from 4.19.2 to 4.20.0

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,4 @@
+- Add User Name, path request URL and request body to AccessLogger (#541)
+- Add Access Logger Patterns to match to Access Logger (#541)
 - Upgrade body-parser dep from 1.20.0 to 1.20.3
 - Upgrade express from 4.19.2 to 4.20.0

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,6 +1,6 @@
-- Add User name, request path, query and body to AccessLogger (#541)
-- Ensure Origin of AccesLogger show x-forwarderd-for header if exists
-- Add Access Logger Patterns to match to Access Logger (#541)
-- Homogenizes format for Access Logger with pep logs
+- Add: user name, request path, query and body to AccessLogger (#541)
+- Add: Access Logger Patterns to match to Access Logger (#541)
+- Fix: ensure Origin of AccesLogger show x-forwarderd-for header if exists
+- Fix: Homogenizes format for Access Logger with pep logs
 - Upgrade body-parser dep from 1.20.0 to 1.20.3
 - Upgrade express from 4.19.2 to 4.20.0

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,5 @@
-- Add User Name, path request URL and request body to AccessLogger (#541)
+- Add User name, request path, query and body to AccessLogger (#541)
+- Ensure Origin of AccesLogger show x-forwarderd-for header if exists
 - Add Access Logger Patterns to match to Access Logger (#541)
 - Upgrade body-parser dep from 1.20.0 to 1.20.3
 - Upgrade express from 4.19.2 to 4.20.0

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,6 +1,6 @@
 - Add: user name, request path, query and body to AccessLogger (#541)
 - Add: Access Logger Patterns to match to Access Logger (#541)
 - Fix: ensure Origin of AccesLogger show x-forwarderd-for header if exists
-- Fix: Homogenizes format for Access Logger with pep logs
+- Fix: use pipe-separeted format in Access Logger instead of JSON (closer to pep regular log)
 - Upgrade body-parser dep from 1.20.0 to 1.20.3
 - Upgrade express from 4.19.2 to 4.20.0

--- a/README.md
+++ b/README.md
@@ -466,8 +466,10 @@ Example of access log:
 Additionally a file configAccessMatch could be provided to pep to check matches about some elements involved in current access, regardless is right or not right access. For example:
 * List for users involved
 * List of headers and values
-+ List of subpaths in URL request
+* List of subpaths in URL request
 * List of strings in body
+
+This is an example of file `configAccessMatch.js`:
 
 ```
 // Activity related with a list of users
@@ -492,7 +494,7 @@ configAccessMatch.body = [
 ];
 ```
 
-When any of theses patterns maches in current access message access is added with `MATCHED <element> <value>` , where `<element>` would be: `USER`, `HEADER Service`, `HEADER SubService`, HEADER Origin, SUBPATH, BODY and `<value>` the value which matches.  For example:
+When any of theses patterns maches in current access message access is added with `MATCHED <element> <value>` , where `<element>` would be: `USER`, `HEADER Service`, `HEADER SubService`, `HEADER Origin`, `SUBPATH`, `BODY` and `<value>` the value which matches. For example:
 
 ```
 {"level":"info","message":"Right Attempt MATCHED HEADER Service smartcity | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Body={} | Date=2024-10-08T09:25:30.441Z","timestamp":"2024-10-08T09:25:30.441Z"}

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ Accounting access log include data about:
 * Date
 Example of access log:
 ```
-{"level":"info","message":"Right Attempt | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Query={\"limit\":\"15\",\"offset\":\"0\",\"options\":\"count\"} | Body={} | Date=2024-10-08T09:25:30.441Z","timestamp":"2024-10-08T09:25:30.441Z"}
+"Right Attempt | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Query={\"limit\":\"15\",\"offset\":\"0\",\"options\":\"count\"} | Body={} | Date=2024-10-08T09:25:30.441Z"
 ```
 
 Additionally a file configAccessMatch could be provided to pep to check matches about some elements involved in current access, regardless is right or not right access. For example:
@@ -504,7 +504,7 @@ configAccessMatch.body = [
 When any of theses patterns maches in current access message access is added with `MATCHED <element> <value>` , where `<element>` would be: `USER`, `HEADER <header-name>`, `SUBPATH`, `SUBQUERY`, `BODY` and `<value>` the value which matches. For example:
 
 ```
-{"level":"info","message":"Right Attempt MATCHED HEADER fiware-service smartcity | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Query={\"limit\":\"15\",\"offset\":\"0\",\"options\":\"count\"} | Body={} | Date=2024-10-08T09:25:30.441Z","timestamp":"2024-10-08T09:25:30.441Z"}
+Right Attempt MATCHED HEADER fiware-service smartcity | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Query={\"limit\":\"15\",\"offset\":\"0\",\"options\":\"count\"} | Body={} | Date=2024-10-08T09:25:30.441Z"
 ```
 Account log has three modes: `all`, `matched`, `wrong`. First one `all` includes right and wrong access regardles if matches or not. Second one `matched` includes all wrong and just rigth matches acess. And `wrong` monde only includes all wrong access, regardless is maches or not with patterns.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 * [Development documentation](#development)
 
 ## <a name="overview"/> Overview
-The Orion Policy Enforcement Point (PEP) is a proxy meant to secure independent FiWare components, by intercepting every request sent to the component, validating it against the Access Control component. This validation is based in several pieces of data:
+The Policy Enforcement Point (PEP) is a proxy meant to secure independent FiWare components, by intercepting every request sent to the component, validating it against the Access Control component. This validation is based in several pieces of data:
 
 * User token: comes from the OAuth authorization server and is taken from the `x-auth-token` header.
 * ServiceId: is read from the `fiware-service` header and identifies the protected component.
@@ -442,9 +442,9 @@ In order to have the proxy running, there are several basic pieces of informatio
     accountFile: '/tmp/pepAccount.log'
 }
 ```
-Accounting log is only activated when account flag is true, and the logs are produced in a fixed INFO level for accountLogger, redardless of the pep log level.
-Note that accunting log is not rotate, so you should make sure you configure your own rotation system.
-Accounting access log include daba about:
+Accounting log is only activated when account flag is true, and the logs are produced in a fixed INFO level for accessLogger, redardless of the pep log level.
+Note that accounting log is not rotated, so you should make sure you configure your own rotation system.
+Accounting access log include data about:
 * Attempt was right or not
 * Token
 * Origin

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Accounting access log include data about:
 * Date
 Example of access log:
 ```
-{"level":"info","message":"Right Attempt | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Body={} | Date=2024-10-08T09:25:30.441Z","timestamp":"2024-10-08T09:25:30.441Z"}
+{"level":"info","message":"Right Attempt | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Query={\"limit\":\"15\",\"offset\":\"0\",\"options\":\"count\"} | Body={} | Date=2024-10-08T09:25:30.441Z","timestamp":"2024-10-08T09:25:30.441Z"}
 ```
 
 Additionally a file configAccessMatch could be provided to pep to check matches about some elements involved in current access, regardless is right or not right access. For example:
@@ -503,7 +503,7 @@ configAccessMatch.body = [
 When any of theses patterns maches in current access message access is added with `MATCHED <element> <value>` , where `<element>` would be: `USER`, `HEADER Service`, `HEADER SubService`, `HEADER Origin`, `SUBPATH`, `SUBQUERY`, `BODY` and `<value>` the value which matches. For example:
 
 ```
-{"level":"info","message":"Right Attempt MATCHED HEADER Service smartcity | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Body={} | Date=2024-10-08T09:25:30.441Z","timestamp":"2024-10-08T09:25:30.441Z"}
+{"level":"info","message":"Right Attempt MATCHED HEADER Service smartcity | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Query={\"limit\":\"15\",\"offset\":\"0\",\"options\":\"count\"} | Body={} | Date=2024-10-08T09:25:30.441Z","timestamp":"2024-10-08T09:25:30.441Z"}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ Accounting access log include data about:
 * Path
 * Body
 * Date
+* Query
 Example of access log:
 ```
 "Right Attempt | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Query={\"limit\":\"15\",\"offset\":\"0\",\"options\":\"count\"} | Body={} | Date=2024-10-08T09:25:30.441Z"

--- a/README.md
+++ b/README.md
@@ -439,7 +439,8 @@ In order to have the proxy running, there are several basic pieces of informatio
     port: 7070,
     path: '/pdp/v3',
     account: false,
-    accountFile: '/tmp/pepAccount.log'
+    accountFile: '/tmp/pepAccount.log',
+    accountMode: 'all'
 }
 ```
 Accounting log is only activated when account flag is true, and the logs are produced in a fixed INFO level for accessLogger, redardless of the pep log level.
@@ -505,7 +506,7 @@ When any of theses patterns maches in current access message access is added wit
 ```
 {"level":"info","message":"Right Attempt MATCHED HEADER Service smartcity | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Query={\"limit\":\"15\",\"offset\":\"0\",\"options\":\"count\"} | Body={} | Date=2024-10-08T09:25:30.441Z","timestamp":"2024-10-08T09:25:30.441Z"}
 ```
-
+Account log has three modes: `all`, `matched`, `wrong`. First one `all` includes right and wrong access regardles if matches or not. Second one `matched` includes all wrong and just rigth matches acess. And `wrong` monde only includes all wrong access, regardless is maches or not with patterns.
 
 ```
 * `config.componentName`: name of the component that will be used to compose the FRN that will identify the resource to be accessed. E.g.: `orion`.

--- a/README.md
+++ b/README.md
@@ -465,6 +465,8 @@ Example of access log:
 "Right Attempt | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Query={\"limit\":\"15\",\"offset\":\"0\",\"options\":\"count\"} | Body={} | Date=2024-10-08T09:25:30.441Z"
 ```
 
+Note that the above format is not the same than the regular PEP log (although it is also based in fields separated by `|`, the fields themselves are not the same).
+
 Additionally a file configAccessMatch could be provided to pep to check matches about some elements involved in current access, regardless is right or not right access. For example:
 * List for users involved
 * List of headers and values

--- a/README.md
+++ b/README.md
@@ -504,12 +504,12 @@ configAccessMatch.body = [
 ];
 ```
 
-When any of theses patterns maches in current access message access is added with `MATCHED <element> <value>` , where `<element>` would be: `USER`, `HEADER <header-name>`, `SUBPATH`, `SUBQUERY`, `BODY` and `<value>` the value which matches. For example:
+When any of theses patterns matches in current access, message access is added with `MATCHED <element> <value>` , where `<element>` would be: `USER`, `HEADER <header-name>`, `SUBPATH`, `SUBQUERY`, `BODY` and `<value>` the value which matches. For example:
 
 ```
 Right Attempt MATCHED HEADER fiware-service smartcity | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Query={\"limit\":\"15\",\"offset\":\"0\",\"options\":\"count\"} | Body={} | Date=2024-10-08T09:25:30.441Z"
 ```
-Account log has three modes: `all`, `matched`, `wrong`. First one `all` includes right and wrong access regardles if matches or not. Second one `matched` includes all wrong and just rigth matches acess. And `wrong` monde only includes all wrong access, regardless is maches or not with patterns.
+Account log has three modes: `all`, `matched`, `wrong`. First one `all` includes right and wrong access regardles if matches or not. Second one `matched` includes all wrong and just rigth matches acess. And `wrong` mode only includes all wrong access, regardless is matches or not with patterns.
 
 ```
 * `config.componentName`: name of the component that will be used to compose the FRN that will identify the resource to be accessed. E.g.: `orion`.

--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ Additionally a file configAccessMatch could be provided to pep to check matches 
 * List for users involved
 * List of headers and values
 * List of subpaths in URL request
+* List of subqueries in query request
 * List of strings in body
 
 This is an example of file `configAccessMatch.js`:
@@ -488,13 +489,18 @@ configAccessMatch.subpaths = [
     '/v1',
 ];
 
+// Activity related with request including the following subqueries
+configAccessMatch.subqueries = [
+    'flowControl', 'options',
+];
+
 // Activity related with request including the following strings in body
 configAccessMatch.body = [
     'legacy',
 ];
 ```
 
-When any of theses patterns maches in current access message access is added with `MATCHED <element> <value>` , where `<element>` would be: `USER`, `HEADER Service`, `HEADER SubService`, `HEADER Origin`, `SUBPATH`, `BODY` and `<value>` the value which matches. For example:
+When any of theses patterns maches in current access message access is added with `MATCHED <element> <value>` , where `<element>` would be: `USER`, `HEADER Service`, `HEADER SubService`, `HEADER Origin`, `SUBPATH`, `SUBQUERY`, `BODY` and `<value>` the value which matches. For example:
 
 ```
 {"level":"info","message":"Right Attempt MATCHED HEADER Service smartcity | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Body={} | Date=2024-10-08T09:25:30.441Z","timestamp":"2024-10-08T09:25:30.441Z"}

--- a/README.md
+++ b/README.md
@@ -501,10 +501,10 @@ configAccessMatch.body = [
 ];
 ```
 
-When any of theses patterns maches in current access message access is added with `MATCHED <element> <value>` , where `<element>` would be: `USER`, `HEADER Service`, `HEADER SubService`, `HEADER Origin`, `SUBPATH`, `SUBQUERY`, `BODY` and `<value>` the value which matches. For example:
+When any of theses patterns maches in current access message access is added with `MATCHED <element> <value>` , where `<element>` would be: `USER`, `HEADER <header-name>`, `SUBPATH`, `SUBQUERY`, `BODY` and `<value>` the value which matches. For example:
 
 ```
-{"level":"info","message":"Right Attempt MATCHED HEADER Service smartcity | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Query={\"limit\":\"15\",\"offset\":\"0\",\"options\":\"count\"} | Body={} | Date=2024-10-08T09:25:30.441Z","timestamp":"2024-10-08T09:25:30.441Z"}
+{"level":"info","message":"Right Attempt MATCHED HEADER fiware-service smartcity | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Query={\"limit\":\"15\",\"offset\":\"0\",\"options\":\"count\"} | Body={} | Date=2024-10-08T09:25:30.441Z","timestamp":"2024-10-08T09:25:30.441Z"}
 ```
 Account log has three modes: `all`, `matched`, `wrong`. First one `all` includes right and wrong access regardles if matches or not. Second one `matched` includes all wrong and just rigth matches acess. And `wrong` monde only includes all wrong access, regardless is maches or not with patterns.
 

--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ configAccessMatch.body = [
 ];
 ```
 
-When any of theses patterns maches in current access message access is added with `MATCHED <element> <value>` . For example:
+When any of theses patterns maches in current access message access is added with `MATCHED <element> <value>` , where `<element>` would be: `USER`, `HEADER Service`, `HEADER SubService`, HEADER Origin, SUBPATH, BODY and `<value>` the value which matches.  For example:
 
 ```
 {"level":"info","message":"Right Attempt MATCHED HEADER Service smartcity | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Body={} | Date=2024-10-08T09:25:30.441Z","timestamp":"2024-10-08T09:25:30.441Z"}

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ Additionally a file configAccessMatch could be provided to pep to check matches 
 * List of subqueries in query request
 * List of strings in body
 
-This is an example of file `configAccessMatch.js`:
+This is an example of file `configAccessMatch.js` (full path /opt/fiware-pep-steelskin/configAccessMatch.js i.e. in a docker image):
 
 ```
 // Activity related with a list of users

--- a/README.md
+++ b/README.md
@@ -474,7 +474,9 @@ Additionally a file configAccessMatch could be provided to pep to check matches 
 * List of subqueries in query request
 * List of strings in body
 
-This is an example of file `configAccessMatch.js` (full path /opt/fiware-pep-steelskin/configAccessMatch.js i.e. in a docker image):
+PEP reloads this file each time it changes without needing restarting PEP itself.
+
+This is an example of file `configAccessMatch.js` (full path `/opt/fiware-pep-steelskin/configAccessMatch.js` i.e. in a docker image):
 
 ```
 // Activity related with a list of users

--- a/README.md
+++ b/README.md
@@ -449,13 +449,56 @@ Accounting access log include daba about:
 * Token
 * Origin
 * UserId
+* UserName
 * ServiceId
+* Service
 * SubServiceId
+* SubService
 * Action
+* Path
+* Body
 * Date
 Example of access log:
 ```
-Right Attempt | ResponseStatus=200 | Token=860864fb6d1a4c8a8cb7d59d16daaa52 | Origin=192.168.1.125 | UserId=62c63ada8694451fb67a341346172499 | ServiceId=a9b38dd2a97e4944b2daebdb74ed60ff | Service=smartgondor | SubServiceId=/ | SubService=/ | Action=read | Date=2017-09-21T12:46:57.844Z
+{"level":"info","message":"Right Attempt | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Body={} | Date=2024-10-08T09:25:30.441Z","timestamp":"2024-10-08T09:25:30.441Z"}
+```
+
+Additionally a file configAccessMatch could be provided to pep to check matches about some elements involved in current access, regardless is right or not right access. For example:
+* List for users involved
+* List of headers and values
++ List of subpaths in URL request
+* List of strings in body
+
+```
+// Activity related with a list of users
+configAccessMatch.users = [
+    'cracker1', 'cracker2',
+];
+
+// Activity related with request which the following headers
+configAccessMatch.headers = [
+    { "fiware-service": "smartcity" },
+    { "x-real-ip": "127.0.0.1" }
+];
+
+// Activity related with request including the following subpaths
+configAccessMatch.subpaths = [
+    '/v1',
+];
+
+// Activity related with request including the following strings in body
+configAccessMatch.body = [
+    'legacy',
+];
+```
+
+When any of theses patterns maches in current access message access is added with `MATCHED <element> <value>` . For example:
+
+```
+{"level":"info","message":"Right Attempt MATCHED HEADER Service smartcity | ResponseStatus=200 | Token=gAAAAABnBPgPrgwpcAkbQOZIryu5ADUIScyorN3vbPYbTJxTE5AF3RO1y25Tf-sL3EKzvfr_1U3u8IL8ylB4e4B_vD5yZjc9rnrSIqoiC77B7uZ1O1xZCyukq_MkjRxJLqA9yQ5lQtAQCC6ig7Kn5uPhpPD-mhVb7kyQjUw1QjtCiyP7UKXZvKU | Origin=172.17.0.22 | UserId=753b954985bf460fabbd6953c71d50c7 | UserName=adm1 | ServiceId=9f710408f5944c3993db600810e97c83 | Service=smartcity | SubServiceId=/ | SubService=/ | Action=read | Path=/v2/entities | Body={} | Date=2024-10-08T09:25:30.441Z","timestamp":"2024-10-08T09:25:30.441Z"}
+```
+
+
 ```
 * `config.componentName`: name of the component that will be used to compose the FRN that will identify the resource to be accessed. E.g.: `orion`.
 * `config.resourceNamePrefix`: string prefix that will be used to compose the FRN that will identify the resource to be accessed. E.g.: `fiware:`.

--- a/bin/pepProxy
+++ b/bin/pepProxy
@@ -48,6 +48,7 @@ function loadConfiguration() {
         'ACCESS_PROTOCOL',
         'ACCESS_ACCOUNT',
         'ACCESS_ACCOUNTFILE',
+        'ACCESS_ACCOUNTMODE',
         'ADMIN_PORT',
         'AUTHENTICATION_HOST',
         'AUTHENTICATION_PORT',
@@ -102,6 +103,9 @@ function loadConfiguration() {
     }
     if (process.env.ACCESS_ACCOUNTFILE) {
         config.access.accountFile = process.env.ACCESS_ACCOUNTFILE;
+    }
+    if (process.env.ACCESS_ACCOUNTMODE) {
+        config.access.accountMode = process.env.ACCESS_ACCOUNTMODE;
     }
     if (process.env.AUTHENTICATION_HOST) {
         config.authentication.options.host = process.env.AUTHENTICATION_HOST;

--- a/config.js
+++ b/config.js
@@ -64,7 +64,11 @@ config.access = {
     /**
      * Log Account file
      */
-    accountFile: '/tmp/pepAccount.log'
+    accountFile: '/tmp/pepAccount.log',
+    /**
+     * Account mode: `all`, `matched`, `wrong`
+     */
+    accountMode: 'all'
 };
 
 // User identity configuration

--- a/configAccessMatch.js
+++ b/configAccessMatch.js
@@ -12,11 +12,12 @@ configAccessMatch.users = [
 
 // Activity related with request which the following headers
 configAccessMatch.headers = [
-    { "Fiware-service": "smartcity" },
+    { "fiware-service": "smartcity" },
+    { "x-real-ip": "127.0.0.1" }
 ];
 
 // Activity related with request including the following subpaths
-configAccessMatch.subpath = [
+configAccessMatch.subpaths = [
     '/v1',
 ];
 

--- a/configAccessMatch.js
+++ b/configAccessMatch.js
@@ -21,6 +21,11 @@ configAccessMatch.subpaths = [
     '/v1',
 ];
 
+// Activity related with request including the following subqueries
+configAccessMatch.subqueries = [
+    'flowControl', 'options',
+];
+
 // Activity related with request including the following strings in body
 configAccessMatch.body = [
     'legacy'

--- a/configAccessMatch.js
+++ b/configAccessMatch.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/**
+ * List of access match
+ */
+var configAccessMatch = {};
+
+// Activity related with a list of users
+configAccessMatch.users = [
+    'cloud_admin', 'pep',
+];
+
+// Activity related with request which the following headers
+configAccessMatch.headers = [
+    { "Fiware-service": "smartcity" },
+];
+
+// Activity related with request including the following subpaths
+configAccessMatch.subpath = [
+    '/v1',
+];
+
+// Activity related with request including the following strings in body
+configAccessMatch.body = [
+    'legacy'
+];
+
+
+exports.configAccessMatch = configAccessMatch;

--- a/configAccessMatch.js
+++ b/configAccessMatch.js
@@ -7,28 +7,28 @@ var configAccessMatch = {};
 
 // Activity related with a list of users
 configAccessMatch.users = [
-    'user1', 'user2',
+    // 'user1', 'user2',
 ];
 
 // Activity related with request which the following headers
 configAccessMatch.headers = [
-    { "fiware-service": "smartcity" },
-    { "x-real-ip": "127.0.0.1" }
+    // { "fiware-service": "smartcity" },
+    // { "x-real-ip": "127.0.0.1" }
 ];
 
 // Activity related with request including the following subpaths
 configAccessMatch.subpaths = [
-    '/v1',
+    // '/v1',
 ];
 
 // Activity related with request including the following subqueries
 configAccessMatch.subqueries = [
-    'flowControl', 'options',
+    // 'flowControl',
 ];
 
 // Activity related with request including the following strings in body
 configAccessMatch.body = [
-    'legacy'
+    // 'legacy'
 ];
 
 

--- a/configAccessMatch.js
+++ b/configAccessMatch.js
@@ -7,7 +7,7 @@ var configAccessMatch = {};
 
 // Activity related with a list of users
 configAccessMatch.users = [
-    'cloud_admin', 'pep',
+    'user1', 'user2',
 ];
 
 // Activity related with request which the following headers

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -32,7 +32,8 @@ var constants = {
     X_REAL_IP_HEADER: 'x-real-ip',
     CORRELATOR_HEADER: 'fiware-correlator',
 
-    GET_ROLES_PATH: '/user'
+    GET_ROLES_PATH: '/user',
+    NA: 'N/A'
 };
 
 

--- a/lib/fiware-pep-steelskin.js
+++ b/lib/fiware-pep-steelskin.js
@@ -79,7 +79,7 @@ function accountInfoError(error, req, res, next) {
     accessLogger.info(accessMsg +
                       ' | Error=' + error.name +
                       ' | Token=' + req.headers['x-auth-token'] +
-                      ' | Origin=' + req.connection.remoteAddress +
+                      ' | Origin=' + (req.ip || req.connection.remoteAddress) +
                       ' | UserId=' + req.userId +
                       ' | ServiceId=' + req.serviceId +
                       ' | UserName=' + req.userName +

--- a/lib/fiware-pep-steelskin.js
+++ b/lib/fiware-pep-steelskin.js
@@ -88,6 +88,7 @@ function accountInfoError(error, req, res, next) {
                       ' | SubService=' + req.subService +
                       ' | Action=' + req.action +
                       ' | Path=' + req.path +
+                      ' | Query=' + JSON.stringify(req.query) +
                       ' | Body=' + JSON.stringify(req.body) +
                       ' | Date=' + new Date().toJSON());
     next(error);

--- a/lib/fiware-pep-steelskin.js
+++ b/lib/fiware-pep-steelskin.js
@@ -74,7 +74,9 @@ function handleError(error, req, res, next) {
  * @param {Function} next        Call to the next error handler in the chain.
  */
 function accountInfoError(error, req, res, next) {
-    accessLogger.info('Wrong Attempt' +
+    var accessMsg = 'Wrong Attempt';
+    accessMsg = proxyMiddleware.checkAccessMatches(req, accessMsg);
+    accessLogger.info(accessMsg +
                       ' | Error=' + error.name +
                       ' | Token=' + req.headers['x-auth-token'] +
                       ' | Origin=' + req.connection.remoteAddress +

--- a/lib/fiware-pep-steelskin.js
+++ b/lib/fiware-pep-steelskin.js
@@ -85,6 +85,8 @@ function accountInfoError(error, req, res, next) {
                       ' | SubServiceId=' + req.subserviceId +
                       ' | SubService=' + req.subService +
                       ' | Action=' + req.action +
+                      ' | Path=' + req.path +
+                      ' | Body=' + JSON.stringify(req.body) +
                       ' | Date=' + new Date().toJSON());
     next(error);
 }

--- a/lib/fiware-pep-steelskin.js
+++ b/lib/fiware-pep-steelskin.js
@@ -79,7 +79,10 @@ function accountInfoError(error, req, res, next) {
                       ' | Token=' + req.headers['x-auth-token'] +
                       ' | Origin=' + req.connection.remoteAddress +
                       ' | UserId=' + req.userId +
+                      ' | ServiceId=' + req.serviceId +
+                      ' | UserName=' + req.userName +
                       ' | Service=' + req.service +
+                      ' | SubServiceId=' + req.subserviceId +
                       ' | SubService=' + req.subService +
                       ' | Action=' + req.action +
                       ' | Date=' + new Date().toJSON());

--- a/lib/fiware-pep-steelskin.js
+++ b/lib/fiware-pep-steelskin.js
@@ -123,6 +123,7 @@ function setAccessLogger() {
             })
         ]
     });
+    proxyMiddleware.watchConfigAccessMatchFile();
 }
 
 /**

--- a/lib/fiware-pep-steelskin.js
+++ b/lib/fiware-pep-steelskin.js
@@ -122,7 +122,10 @@ function setAccessLogger() {
         level: 'info',
         transports: [
             new(winston.transports.File)({
-                filename: config.access.accountFile
+                filename: config.access.accountFile,
+                json: false,
+                timestamp: false,
+                showLevel: false
             })
         ]
     });

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -250,7 +250,7 @@ function accountInfo(req, res, next) {
                 level: 'info',
                 transports: [
                     new(winston.transports.File)({
-                        filename: config.access.accountFile
+                        filename: config.access.accountFile,
                         json: false,
                         timestamp: false,
                         showLevel: false

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -197,7 +197,6 @@ function sendRequest(req, res, next) {
     next();
 }
 
-    // Check here MATCH file patterns:
 /**
  * Check here MATCH file patterns
  *

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -201,6 +201,7 @@ function accountInfo(req, res, next) {
                               ' | Token=' + req.headers['x-auth-token'] +
                               ' | Origin=' + req.connection.remoteAddress +
                               ' | UserId=' + req.userId +
+                              ' | UserName=' + req.userName +
                               ' | ServiceId=' + req.serviceId +
                               ' | Service=' + req.service +
                               ' | SubServiceId=' + req.subserviceId +

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -209,17 +209,10 @@ function checkAccessMatches(req, accessMsg) {
         accessMsg += ' MATCHED USER ' + req.userName;
     }
     for (var header of configAccessMatch.headers) {
-        if (Object.keys(header).includes('fiware-service')) {
-            if (req.service.includes(header['fiware-service'])) {
-                accessMsg += ' MATCHED HEADER Service ' + header['fiware-service'];
-            }
-        } else if (Object.keys(header).includes('fiware-servicepath')) {
-            if (req.subService.includes(header['fiware-servicepath'])) {
-                accessMsg += ' MATCHED HEADER SubService ' + header['fiware-servicepath'];
-            }
-        } else if (Object.keys(header).includes('x-real-ip')) {
-            if (req.connection.remoteAddress.includes(header['x-real-ip'])) {
-                accessMsg += ' MATCHED HEADER Origin ' + header['x-real-ip'];
+        var headerName = Object.keys(header)[0];
+        if (Object.keys(req.headers).includes(headerName)) {
+            if (req.headers[headerName] === header[headerName]) {
+                accessMsg += ' MATCHED HEADER ' + headerName + ' ' + header[headerName];
             }
         }
     }

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -221,10 +221,6 @@ function checkAccessMatches(req, accessMsg) {
             if (req.connection.remoteAddress.includes(header['x-real-ip'])) {
                 accessMsg += ' MATCHED HEADER Origin ' + header['x-real-ip'];
             }
-        // } else if (Object.keys(header).includes('x-forwarded-for')) {
-        //     if (req.headers.includes(header['x-forwarded-for'])) {
-        //         accessMsg += ' MATCHED HEADER x-forwarded-for ' + header['x-forwarded-for'];
-        //     }
         }
     }
     for (var subpath of configAccessMatch.subpaths) {
@@ -267,23 +263,31 @@ function accountInfo(req, res, next) {
             });
         }
         req.fwdResponse = req.fwdResponse.on('response', function(res) {
-            var accessMsg = 'Right Attempt';
-            accessMsg = checkAccessMatches(req, accessMsg);
-            accessLogger.info(accessMsg +
-                              ' | ResponseStatus=' + req.fwdResponse.response.statusCode +
-                              ' | Token=' + req.headers['x-auth-token'] +
-                              ' | Origin=' + req.connection.remoteAddress +
-                              ' | UserId=' + req.userId +
-                              ' | UserName=' + req.userName +
-                              ' | ServiceId=' + req.serviceId +
-                              ' | Service=' + req.service +
-                              ' | SubServiceId=' + req.subserviceId +
-                              ' | SubService=' + req.subService +
-                              ' | Action=' + req.action +
-                              ' | Path=' + req.path +
-                              ' | Query=' + JSON.stringify(req.query) +
-                              ' | Body=' + JSON.stringify(req.body).slice(0, 100) + // not all body
-                              ' | Date=' + new Date().toJSON());
+            var accessMsgOrig = 'Right Attempt';
+            var accessMsg = accessMsgOrig;
+            if (! ['wrong'].includes(config.access.accountMode) ) {
+                accessMsg = checkAccessMatches(req, accessMsgOrig);
+            }
+            if ( ['all'].includes(config.access.accountMode) ||
+                 (['matched'].includes(config.access.accountMode) &&
+                  accessMsgOrig.length < accessMsg.length) ){
+
+                accessLogger.info(accessMsg +
+                                  ' | ResponseStatus=' + req.fwdResponse.response.statusCode +
+                                  ' | Token=' + req.headers['x-auth-token'] +
+                                  ' | Origin=' + req.connection.remoteAddress +
+                                  ' | UserId=' + req.userId +
+                                  ' | UserName=' + req.userName +
+                                  ' | ServiceId=' + req.serviceId +
+                                  ' | Service=' + req.service +
+                                  ' | SubServiceId=' + req.subserviceId +
+                                  ' | SubService=' + req.subService +
+                                  ' | Action=' + req.action +
+                                  ' | Path=' + req.path +
+                                  ' | Query=' + JSON.stringify(req.query) +
+                                  ' | Body=' + JSON.stringify(req.body).slice(0, 100) + // not all body
+                                  ' | Date=' + new Date().toJSON());
+            }
         });
     }
     next();

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -218,7 +218,7 @@ function accountInfo(req, res, next) {
             });
         }
         req.fwdResponse = req.fwdResponse.on('response', function(res) {
-            var accessMsg = "Right Attempt";
+            var accessMsg = 'Right Attempt';
 
             // CHeck here MATCH file patterns:
             if (req.userName in configAccessMatch.users ) {

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -207,6 +207,8 @@ function accountInfo(req, res, next) {
                               ' | SubServiceId=' + req.subserviceId +
                               ' | SubService=' + req.subService +
                               ' | Action=' + req.action +
+                              ' | Path=' + req.path +
+                              ' | Body=' + JSON.stringify(req.body).slice(0, 100) +
                               ' | Date=' + new Date().toJSON());
         });
     }

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -221,11 +221,20 @@ function checkAccessMatches(req, accessMsg) {
             if (req.connection.remoteAddress.includes(header['x-real-ip'])) {
                 accessMsg += ' MATCHED HEADER Origin ' + header['x-real-ip'];
             }
+        // } else if (Object.keys(header).includes('x-forwarded-for')) {
+        //     if (req.headers.includes(header['x-forwarded-for'])) {
+        //         accessMsg += ' MATCHED HEADER x-forwarded-for ' + header['x-forwarded-for'];
+        //     }
         }
     }
     for (var subpath of configAccessMatch.subpaths) {
         if (req.path.includes(subpath)) {
             accessMsg += ' MATCHED SUBPATH ' + subpath;
+        }
+    }
+    for (var subquery of configAccessMatch.subqueries) {
+        if (JSON.stringify(req.query).includes(subquery)) {
+            accessMsg += ' MATCHED SUBQUERY ' + subquery;
         }
     }
     for (var text of configAccessMatch.body) {

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -222,7 +222,32 @@ function accountInfo(req, res, next) {
 
             // CHeck here MATCH file patterns:
             if (req.userName in configAccessMatch.users ) {
-                accessMsg += '  MATCHED USER';
+                accessMsg += ' MATCHED USER';
+            }
+            for (var header of configAccessMatch.headers) {
+                if ('fiware-service' in Object.keys(header)) {
+                    if (req.service.includes(header['fiware-service'])) {
+                        accessMsg += ' MATCHED HEADER Service';
+                    }
+                } else if ('fiware-servicepath' in Object.keys(header)) {
+                    if (req.subService.includes(header['fiware-servicepath'])) {
+                        accessMsg += ' MATCHED HEADER SubService';
+                    }
+                } else if ('x-real-ip' in Object.keys(header)) {
+                    if (req.connection.remoteAddress.includes(header['x-real-ip'])) {
+                        accessMsg += ' MATCHED HEADER Origin';
+                    }
+                }
+            }
+            for (var subpath of configAccessMatch.subpaths) {
+                if (req.path.includes(subpath)) {
+                    accessMsg += ' MATCHED SUBPATH ' + subpath;
+                }
+            }
+            for (var text of configAccessMatch.body) {
+                if (JSON.stringify(req.body).includes(text)) {
+                    accessMsg += ' MATCHED BODY ' + text;
+                }
             }
 
             accessLogger.info(accessMsg +
@@ -237,7 +262,7 @@ function accountInfo(req, res, next) {
                               ' | SubService=' + req.subService +
                               ' | Action=' + req.action +
                               ' | Path=' + req.path +
-                              ' | Body=' + JSON.stringify(req.body).slice(0, 100) +
+                              ' | Body=' + JSON.stringify(req.body).slice(0, 100) + // not all body
                               ' | Date=' + new Date().toJSON());
         });
     }

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -281,6 +281,7 @@ function accountInfo(req, res, next) {
                               ' | SubService=' + req.subService +
                               ' | Action=' + req.action +
                               ' | Path=' + req.path +
+                              ' | Query=' + JSON.stringify(req.query) +
                               ' | Body=' + JSON.stringify(req.body).slice(0, 100) + // not all body
                               ' | Date=' + new Date().toJSON());
         });

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -36,7 +36,29 @@ var config = require('../../config'),
         'x-auth-token'
     ],
     winston = require('winston'),
+    logger = require('logops'),
+    configAccessMatch = require('../../configAccessMatch.js').configAccessMatch,
     accessLogger;
+
+const fs = require('fs');
+const configAccessMatchFilePath = './configAccessMatch.js';
+
+function requireUncached(module) {
+    delete require.cache[require.resolve(module)];
+    return require(module);
+}
+
+function watchConfigAccessMatchFile() {
+    fs.watch(configAccessMatchFilePath, (event, filename) => {
+        logger.info('watchConfigAccessMatchFile changed by %s detected in file %s', event, filename);
+        try {
+            configAccessMatch = requireUncached('../../configAccessMatch.js').configAccessMatch;
+            logger.debug('reloaded configAccessMatch %j', configAccessMatch);
+        } catch (err) {
+            logger.error('Error %s reloading module: %s ', err, filename);
+        }
+    });
+}
 
 /**
  * Middleware to extract the organization data from the request.
@@ -196,7 +218,14 @@ function accountInfo(req, res, next) {
             });
         }
         req.fwdResponse = req.fwdResponse.on('response', function(res) {
-            accessLogger.info('Right Attempt' +
+            var accessMsg = "Right Attempt";
+
+            // CHeck here MATCH file patterns:
+            if (req.userName in configAccessMatch.users ) {
+                accessMsg += '  MATCHED USER';
+            }
+
+            accessLogger.info(accessMsg +
                               ' | ResponseStatus=' + req.fwdResponse.response.statusCode +
                               ' | Token=' + req.headers['x-auth-token'] +
                               ' | Origin=' + req.connection.remoteAddress +
@@ -260,3 +289,4 @@ exports.sendResponse = sendResponse;
 exports.accountInfo = accountInfo;
 exports.checkMandatoryHeaders = checkMandatoryHeaders(validationHeaders);
 exports.checkAuthorizationHeader = checkMandatoryHeaders(authorizationHeaders);
+exports.watchConfigAccessMatchFile = watchConfigAccessMatchFile;

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -268,7 +268,7 @@ function accountInfo(req, res, next) {
                 accessLogger.info(accessMsg +
                                   ' | ResponseStatus=' + req.fwdResponse.response.statusCode +
                                   ' | Token=' + req.headers['x-auth-token'] +
-                                  ' | Origin=' + req.connection.remoteAddress +
+                                  ' | Origin=' + (req.ip || req.connection.remoteAddress) +
                                   ' | UserId=' + req.userId +
                                   ' | UserName=' + req.userName +
                                   ' | ServiceId=' + req.serviceId +

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -197,6 +197,47 @@ function sendRequest(req, res, next) {
     next();
 }
 
+    // Check here MATCH file patterns:
+/**
+ * Check here MATCH file patterns
+ *
+ * @param {Object} req           Incoming request.
+ * @param {String} accessMsg     Incoming accessMsg
+ * @return {String}              String message corresponding with accessMsg and found matches
+ */
+function checkAccessMatches(req, accessMsg) {
+    if (req.userName in configAccessMatch.users ) {
+        accessMsg += ' MATCHED USER ' + req.userName;
+    }
+    for (var header of configAccessMatch.headers) {
+        if (Object.keys(header).includes('fiware-service')) {
+            if (req.service.includes(header['fiware-service'])) {
+                accessMsg += ' MATCHED HEADER Service ' + header['fiware-service'];
+            }
+        } else if (Object.keys(header).includes('fiware-servicepath')) {
+            if (req.subService.includes(header['fiware-servicepath'])) {
+                accessMsg += ' MATCHED HEADER SubService ' + header['fiware-servicepath'];
+            }
+        } else if (Object.keys(header).includes('x-real-ip')) {
+            if (req.connection.remoteAddress.includes(header['x-real-ip'])) {
+                accessMsg += ' MATCHED HEADER Origin ' + header['x-real-ip'];
+            }
+        }
+    }
+    for (var subpath of configAccessMatch.subpaths) {
+        if (req.path.includes(subpath)) {
+            accessMsg += ' MATCHED SUBPATH ' + subpath;
+        }
+    }
+    for (var text of configAccessMatch.body) {
+        if (JSON.stringify(req.body).includes(text)) {
+            accessMsg += ' MATCHED BODY ' + text;
+        }
+    }
+    return accessMsg;
+}
+
+
 /**
  * Account Log
  * read to guess its type.
@@ -219,37 +260,7 @@ function accountInfo(req, res, next) {
         }
         req.fwdResponse = req.fwdResponse.on('response', function(res) {
             var accessMsg = 'Right Attempt';
-
-            // CHeck here MATCH file patterns:
-            if (req.userName in configAccessMatch.users ) {
-                accessMsg += ' MATCHED USER ' + req.userName;
-            }
-            for (var header of configAccessMatch.headers) {
-                if (Object.keys(header).includes('fiware-service')) {
-                    if (req.service.includes(header['fiware-service'])) {
-                        accessMsg += ' MATCHED HEADER Service ' + header['fiware-service'];
-                    }
-                } else if (Object.keys(header).includes('fiware-servicepath')) {
-                    if (req.subService.includes(header['fiware-servicepath'])) {
-                        accessMsg += ' MATCHED HEADER SubService ' + header['fiware-servicepath'];
-                    }
-                } else if (Object.keys(header).includes('x-real-ip')) {
-                    if (req.connection.remoteAddress.includes(header['x-real-ip'])) {
-                        accessMsg += ' MATCHED HEADER Origin ' + header['x-real-ip'];
-                    }
-                }
-            }
-            for (var subpath of configAccessMatch.subpaths) {
-                if (req.path.includes(subpath)) {
-                    accessMsg += ' MATCHED SUBPATH ' + subpath;
-                }
-            }
-            for (var text of configAccessMatch.body) {
-                if (JSON.stringify(req.body).includes(text)) {
-                    accessMsg += ' MATCHED BODY ' + text;
-                }
-            }
-
+            accessMsg = checkAccessMatches(req, accessMsg);
             accessLogger.info(accessMsg +
                               ' | ResponseStatus=' + req.fwdResponse.response.statusCode +
                               ' | Token=' + req.headers['x-auth-token'] +
@@ -315,3 +326,4 @@ exports.accountInfo = accountInfo;
 exports.checkMandatoryHeaders = checkMandatoryHeaders(validationHeaders);
 exports.checkAuthorizationHeader = checkMandatoryHeaders(authorizationHeaders);
 exports.watchConfigAccessMatchFile = watchConfigAccessMatchFile;
+exports.checkAccessMatches = checkAccessMatches;

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -222,20 +222,20 @@ function accountInfo(req, res, next) {
 
             // CHeck here MATCH file patterns:
             if (req.userName in configAccessMatch.users ) {
-                accessMsg += ' MATCHED USER';
+                accessMsg += ' MATCHED USER ' + req.userName;
             }
             for (var header of configAccessMatch.headers) {
-                if ('fiware-service' in Object.keys(header)) {
+                if (Object.keys(header).includes('fiware-service')) {
                     if (req.service.includes(header['fiware-service'])) {
-                        accessMsg += ' MATCHED HEADER Service';
+                        accessMsg += ' MATCHED HEADER Service ' + header['fiware-service'];
                     }
-                } else if ('fiware-servicepath' in Object.keys(header)) {
+                } else if (Object.keys(header).includes('fiware-servicepath')) {
                     if (req.subService.includes(header['fiware-servicepath'])) {
-                        accessMsg += ' MATCHED HEADER SubService';
+                        accessMsg += ' MATCHED HEADER SubService ' + header['fiware-servicepath'];
                     }
-                } else if ('x-real-ip' in Object.keys(header)) {
+                } else if (Object.keys(header).includes('x-real-ip')) {
                     if (req.connection.remoteAddress.includes(header['x-real-ip'])) {
-                        accessMsg += ' MATCHED HEADER Origin';
+                        accessMsg += ' MATCHED HEADER Origin ' + header['x-real-ip'];
                     }
                 }
             }

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -251,6 +251,9 @@ function accountInfo(req, res, next) {
                 transports: [
                     new(winston.transports.File)({
                         filename: config.access.accountFile
+                        json: false,
+                        timestamp: false,
+                        showLevel: false
                     })
                 ]
             });

--- a/lib/services/keystoneAuth.js
+++ b/lib/services/keystoneAuth.js
@@ -191,6 +191,7 @@ function retrieveUser(req, callback) {
             req.serviceId = cachedValue.serviceId;
             req.domainName = cachedValue.domainName;
             req.userId = cachedValue.userId;
+            req.userName = cachedValue.userName;
 
             logger.debug('User value processed with value: %j', cachedValue);
 
@@ -245,7 +246,8 @@ function retrieveUser(req, callback) {
                     cachedValue = {
                         domainName: body.token.project.domain.name,
                         serviceId: body.token.project.domain.id,
-                        userId: body.token['OS-TRUST:trust'].trustor_user.id
+                        userId: body.token['OS-TRUST:trust'].trustor_user.id,
+                        userName: constants.NA
                     };
 
                     innerCb(null, cachedValue);
@@ -256,7 +258,8 @@ function retrieveUser(req, callback) {
                     cachedValue = {
                         domainName: body.token.user.domain.name,
                         serviceId: body.token.user.domain.id,
-                        userId: body.token.user.id
+                        userId: body.token.user.id,
+                        userName: body.token.user.name
                     };
 
                     req.userData = cachedValue;

--- a/lib/services/keystoneAuth.js
+++ b/lib/services/keystoneAuth.js
@@ -250,7 +250,7 @@ function retrieveUser(req, callback) {
                         userName: constants.NA
                     };
                     if (body.token.user) {
-                        cachedValue['userName'] = body.token.user.name;
+                        cachedValue.userName = body.token.user.name;
                     }
                     innerCb(null, cachedValue);
 

--- a/lib/services/keystoneAuth.js
+++ b/lib/services/keystoneAuth.js
@@ -249,7 +249,9 @@ function retrieveUser(req, callback) {
                         userId: body.token['OS-TRUST:trust'].trustor_user.id,
                         userName: constants.NA
                     };
-
+                    if (body.token.user) {
+                        cachedValue['userName'] = body.token.user.name;
+                    }
                     innerCb(null, cachedValue);
 
                 } else if (body.token && body.token.user && body.token.user.domain &&

--- a/operations.md
+++ b/operations.md
@@ -26,6 +26,8 @@ curl -X GET "http://localhost:11211/admin/log"
 
 Every error message is identified with a prefix code in brackets. The code convention can be found in Apendix A.
 
+There is another log about accounting access which is produced when access.account flag is enabled and is done over access.accountFile file. This accounting access logs run always in the a fixed `info` level and logs right and wrong access attempts, providing for each one user, service, subservice, path, date and other relevant info about access. Additionallys some patterns could be configured in order to mark some of these access.
+
 ## <a name="cache"/> Cache management
 
 PEP keeps a memory cache with some access about roles, domains, users and subservices. Related with this info is possible

--- a/operations.md
+++ b/operations.md
@@ -26,7 +26,7 @@ curl -X GET "http://localhost:11211/admin/log"
 
 Every error message is identified with a prefix code in brackets. The code convention can be found in Apendix A.
 
-There is another log about accounting access which is produced when access.account flag is enabled and is done over access.accountFile file. This accounting access logs run always in the a fixed `info` level and logs right and wrong access attempts, providing for each one user, service, subservice, path, date and other relevant info about access. Additionallys some patterns could be configured in order to mark some of these access.
+There is another log about accounting access which is produced when access.account flag is enabled and is done over access.accountFile file. This accounting access logs right and wrong access attempts, providing for each one user, service, subservice, path, date and other relevant info about access. Additionally, some patterns could be configured in order to mark some of these access.
 
 ## <a name="cache"/> Cache management
 


### PR DESCRIPTION
https://github.com/telefonicaid/fiware-pep-steelskin/issues/541

Add to access logger info about:
- [x] User name
- [x] URL request path
- [x] request query
- [x] request body

Add Access match configuration in a file with a watchdog for updates

Check access match by
- [x] Users
- [x] Headers (service, subservice, origin)
- [x] SubPaths
- [x] Subqueries
- [x] Body strings
- [x] Doc about usage